### PR TITLE
WebGLプログラムでメモリリースする不具合を修正

### DIFF
--- a/src/js/game/game-props/generate-game-props.ts
+++ b/src/js/game/game-props/generate-game-props.ts
@@ -92,7 +92,7 @@ export function generateGameProps(params: GamePropsGeneratorParams): GameProps {
       postBattleConnector,
     }),
     renderer,
-    tdSceneBinder: new TDSceneBinder(renderer, hudUIScale),
+    tdSceneBinder: new TDSceneBinder(hudUIScale),
     serviceWorker: null,
     bgm: createBGMManager(),
     se: createSEPlayer(),

--- a/src/js/render/index.ts
+++ b/src/js/render/index.ts
@@ -49,15 +49,6 @@ export class Renderer implements OverlapNotifier, RendererDomGetter, Rendering {
    */
   destructor(): void {
     this.#unsubscriber.forEach((v) => v.unsubscribe());
-    this.dispose();
-  }
-
-  /**
-   * レンダラの持つリソースを解放する
-   * シーン終了時に呼ばれる想定
-   */
-  dispose(): void {
-    this.#threeJsRender.renderLists.dispose();
   }
 
   /**

--- a/src/js/render/index.ts
+++ b/src/js/render/index.ts
@@ -57,7 +57,7 @@ export class Renderer implements OverlapNotifier, RendererDomGetter, Rendering {
    * シーン終了時に呼ばれる想定
    */
   dispose(): void {
-    this.#threeJsRender.dispose();
+    this.#threeJsRender.renderLists.dispose();
   }
 
   /**

--- a/src/js/td-scenes/td-scene-binder.ts
+++ b/src/js/td-scenes/td-scene-binder.ts
@@ -1,7 +1,6 @@
 import { Unsubscribable } from "rxjs";
 
 import { CssHUDUIScale } from "../css/hud-ui-scale";
-import { Renderer } from "../render";
 import { TDScene } from "./td-scene";
 
 /** three.js系シーンをバインドする */
@@ -12,18 +11,14 @@ export class TDSceneBinder {
   #scene: TDScene | null;
   /** cssカスタムプロパティ --hud-ui-scale */
   #hudUIScale: CssHUDUIScale;
-  /** レンダラ管理オブジェクト */
-  #renderer: Renderer;
   /** アンサブスクライバ */
   #unsubscribers: Unsubscribable[];
 
   /**
    * コンストラクタ
-   * @param renderer レンダラ管理オブジェクト
    * @param hudUIScale cssカスタムプロパティ --hud-ui-scale
    */
-  constructor(renderer: Renderer, hudUIScale: CssHUDUIScale) {
-    this.#renderer = renderer;
+  constructor(hudUIScale: CssHUDUIScale) {
     this.#hudUIScale = hudUIScale;
     this.#scene = null;
     this.#domLayerElement = document.createElement("div");
@@ -54,7 +49,6 @@ export class TDSceneBinder {
   dispose(): void {
     this.#scene?.destructor();
     this.#scene = null;
-    this.#renderer.dispose();
     this.#domLayerElement.innerHTML = "";
     this.#unsubscribers.forEach((v) => {
       v.unsubscribe();


### PR DESCRIPTION
This pull request includes several changes to the `TDSceneBinder` class, the `Renderer` class, and the `generateGameProps` function to simplify the code and remove unnecessary dependencies. The most important changes include removing the `Renderer` dependency from `TDSceneBinder`, updating the `generateGameProps` function, and cleaning up the `Renderer` class.

Simplification and dependency removal:

* [`src/js/td-scenes/td-scene-binder.ts`](diffhunk://#diff-e79ec509efdcbdc35007dfc1c46dac45dc7c4d5b5b6d2cd8c1acefd1c78b371dL4): Removed the `Renderer` dependency from the `TDSceneBinder` class, including the constructor and the `dispose` method. [[1]](diffhunk://#diff-e79ec509efdcbdc35007dfc1c46dac45dc7c4d5b5b6d2cd8c1acefd1c78b371dL4) [[2]](diffhunk://#diff-e79ec509efdcbdc35007dfc1c46dac45dc7c4d5b5b6d2cd8c1acefd1c78b371dL15-R21) [[3]](diffhunk://#diff-e79ec509efdcbdc35007dfc1c46dac45dc7c4d5b5b6d2cd8c1acefd1c78b371dL57)
* [`src/js/game/game-props/generate-game-props.ts`](diffhunk://#diff-dc2f6df13b711e47b9da0588aee33aaf2ceebbe35ad3714cad0b80d1078864c2L95-R95): Updated the `generateGameProps` function to instantiate `TDSceneBinder` without the `renderer` parameter.

Code cleanup:

* [`src/js/render/index.ts`](diffhunk://#diff-359532e9bd7d22600383c20f28f24545f026dfeaf7d577d0aa05b5047f608368L52-L60): Removed the `dispose` method from the `Renderer` class and its invocation in the `destructor` method.