### PR TITLE
releaseブランチ修正分をdevelopに取り込む

### DIFF
--- a/buildspec.switchStage.prod.yml
+++ b/buildspec.switchStage.prod.yml
@@ -9,4 +9,5 @@ phases:
       nodejs: 22
   build:
     commands:
-      - ./clear-cdn.bash "${DISTRIBUTION_ID}" "${CLOUD_FRONT_ORIGIN_NAME}" "${STAGE}"
+      - ./switch-stage.bash "${DISTRIBUTION_ID}" "${CLOUD_FRONT_ORIGIN_NAME}" "${STAGE}"
+      - ./clear-cdn.bash "${DISTRIBUTION_ID}"

--- a/buildspec.switchStage.yml
+++ b/buildspec.switchStage.yml
@@ -9,4 +9,5 @@ phases:
       nodejs: 22
   build:
     commands:
-      - ./clear-cdn.bash "${DISTRIBUTION_ID}" "${CLOUD_FRONT_ORIGIN_NAME}" "${STAGE}"
+      - ./switch-stage.bash "${DISTRIBUTION_ID}" "${CLOUD_FRONT_ORIGIN_NAME}" "${STAGE}"
+      - ./clear-cdn.bash "${DISTRIBUTION_ID}"


### PR DESCRIPTION
This pull request includes updates to the buildspec files to modify the sequence of commands executed during the build process. The changes ensure that the `switch-stage.bash` script is run before the `clear-cdn.bash` script.

Changes to buildspec files:

* [`buildspec.switchStage.prod.yml`](diffhunk://#diff-28d2b3726fba9407fae65b8941344342df9e966b79254be89a0b78e334a4a50aL12-R13): Modified the build commands to run `switch-stage.bash` before `clear-cdn.bash`.
* [`buildspec.switchStage.yml`](diffhunk://#diff-49722d2d0f47e59ca185f1c2d2bc990bf8584ebcfc03a9c169041a4d41bb026fL12-R13): Modified the build commands to run `switch-stage.bash` before `clear-cdn.bash`.