### PR TITLE
バースト詳細が空配列の場合にエラーとなる不具合を修正

### DIFF
--- a/src/js/dom-scenes/player-select/armdozer-selector/armdozer-status.ts
+++ b/src/js/dom-scenes/player-select/armdozer-selector/armdozer-status.ts
@@ -178,6 +178,6 @@ export class ArmdozerStatus {
         (v) =>
           `<span class="${ROOT_CLASS_NAME}__burst__content__line">${v}</span>`,
       )
-      .reduce((a, b) => a + b);
+      .reduce((a, b) => a + b, "");
   }
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `ArmdozerStatus` class in the `armdozer-status.ts` file. The change ensures that the `reduce` method has an initial value, which prevents potential issues when the array is empty.

* [`src/js/dom-scenes/player-select/armdozer-selector/armdozer-status.ts`](diffhunk://#diff-5f1e8c936c305781fcf98dc376bd005fc0cd181384c8ad7a39c6927cf4c68893L181-R181): Modified the `reduce` method to include an initial value of an empty string to ensure proper concatenation even when the array is empty.