### PR TITLE
グランドーザのバースト詳細を修正

### DIFF
--- a/src/js/game-description/burst-detail.ts
+++ b/src/js/game-description/burst-detail.ts
@@ -76,7 +76,8 @@ function batteryLimitBreakDetail(burst: BatteryLimitBreak): string[] {
 function forceTurnEndDetail(burst: ForceTurnEnd): string[] {
   return [
     `バッテリーを${burst.recoverBattery}回復する。`,
-    `現在のターンを終了し、自分が攻撃側として新しいターンを開始する。`,
+    `現在のターンを終了し、バッテリー回復なしで自分ターンを開始する。`,
+    `この効果でターン終了した場合、すべてのプレイヤーは「ターン終了時に発動する効果」が無効となる。`,
   ];
 }
 


### PR DESCRIPTION
This pull request includes a change to the `forceTurnEndDetail` function in the `src/js/game-description/burst-detail.ts` file. The change updates the description of the force turn end effect to specify that no battery recovery occurs and that end-of-turn effects are nullified.

Changes to game effect descriptions:

* [`src/js/game-description/burst-detail.ts`](diffhunk://#diff-117f569ff09b016b8bd1b96f449ae08e92a53827c8a27f8418d1b56eb423f150L79-R80): Updated `forceTurnEndDetail` function to clarify that the turn ends without battery recovery and that all end-of-turn effects are nullified.