### PR TITLE
オフセットを追加した

### DIFF
--- a/src/js/game-object/armdozer/mesh/create-outline-mesh.ts
+++ b/src/js/game-object/armdozer/mesh/create-outline-mesh.ts
@@ -58,8 +58,10 @@ type CreateOutlineMeshOptions = ResourcesContainer & {
   outlineWidth: number;
   /** オフセット */
   offset: {
+    /** オフセット x座標 */
+    x?: number;
     /** オフセット y座標 */
-    y: number;
+    y?: number;
   };
 };
 
@@ -88,7 +90,8 @@ export function createOutlineMesh(
     blending: THREE.AdditiveBlending,
   });
   const object = ret.getObject3D();
-  object.position.y = offset.y;
+  object.position.x = offset.x ?? 0;
+  object.position.y = offset.y ?? 0;
   object.position.z = -0.01;
   return ret;
 }

--- a/src/js/game-object/armdozer/mesh/create-standard-mesh.ts
+++ b/src/js/game-object/armdozer/mesh/create-standard-mesh.ts
@@ -17,8 +17,10 @@ type Options = ResourcesContainer & {
   height: number;
   /** オフセット */
   offset: {
+    /** オフセット X座標 */
+    x?: number;
     /** オフセット Y座標 */
-    y: number;
+    y?: number;
   };
 };
 
@@ -37,6 +39,7 @@ export function createStandardMesh(options: Options): ArmdozerAnimation {
     texture,
   });
   const object = ret.getObject3D();
-  object.position.y = offset.y;
+  object.position.x = offset.x ?? 0;
+  object.position.y = offset.y ?? 0;
   return ret;
 }


### PR DESCRIPTION
This pull request includes changes to the `create-outline-mesh.ts` and `create-standard-mesh.ts` files to make the `offset` properties optional and to set default values for these properties when creating meshes. The most important changes are as follows:

Changes to `create-outline-mesh.ts`:

* Made the `offset.x` and `offset.y` properties optional in the `CreateOutlineMeshOptions` type.
* Updated the `createOutlineMesh` function to set default values for `offset.x` and `offset.y` if they are not provided.

Changes to `create-standard-mesh.ts`:

* Made the `offset.x` and `offset.y` properties optional in the `Options` type.
* Updated the `createStandardMesh` function to set default values for `offset.x` and `offset.y` if they are not provided.