### PR TITLE
npmパッケージをアップデートした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.16.12",
+        "@gbraver-burst-network/browser-sdk": "1.16.13",
         "@tweenjs/tween.js": "^25.0.0",
-        "gbraver-burst-core": "1.33.1",
+        "gbraver-burst-core": "1.34.1",
         "handlebars": "^4.7.8",
         "howler": "^2.2.4",
         "jsqr": "^1.4.0",
@@ -47,10 +47,10 @@
         "dependency-cruiser": "^16.8.0",
         "dotenv": "^16.4.7",
         "eslint": "^9.17.0",
-        "eslint-plugin-jest": "^28.9.0",
+        "eslint-plugin-jest": "^28.10.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "glob": "^11.0.0",
-        "globals": "^15.13.0",
+        "globals": "^15.14.0",
         "handlebars-loader": "^1.7.3",
         "html-webpack-plugin": "^5.6.3",
         "http-server": "^14.1.1",
@@ -73,9 +73,9 @@
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
-        "typescript-eslint": "^8.18.0",
+        "typescript-eslint": "^8.18.1",
         "webpack": "^5.97.1",
-        "webpack-cli": "^5.1.4",
+        "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.0"
       },
       "engines": {
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.63",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.63.tgz",
-      "integrity": "sha512-CVxBInifSihIaKJ8Qt8hJF4o5UzpTAMVROqDRG6qflVj9+ricgfk01uOzq1rZBgYlxLrm7+c3Tg2VSivAeNuEA==",
+      "version": "7.0.64",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.64.tgz",
+      "integrity": "sha512-cc/0r1v6cswsj+QWYYlm5AaZ+7mnFpuUygwoovtKqeJRQQMRwiYmBQ2gPSYoBAyXwcJeDfhSJtRUDNcDAsaGcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.621.0",
@@ -113,24 +113,24 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.1.8.tgz",
-      "integrity": "sha512-umBtp4vSOs0jEtm/KLk77bfWBlDnwQmj3EOjryDVUHor1P1jBvE+j7bY7/8S0oOMsPomnWYwupZ+WhLpKIAKow==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.1.9.tgz",
+      "integrity": "sha512-/iY/7Rkxjd1j066UCa5qLj4GssJZ6Tb4c+ra06yekhnrLygU34bs76vGmFCpYk+xLKLIm5uy8tvcwccSYZ2IpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.6.6",
-        "@aws-amplify/api-rest": "4.0.63",
+        "@aws-amplify/api-graphql": "4.6.7",
+        "@aws-amplify/api-rest": "4.0.64",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.6.6.tgz",
-      "integrity": "sha512-j+TIu32LTiBo3PcAkO/22V18pwDIqURbpw86wy2XjT6t/acYldZtEc+fEJa1s4xE3xdqhrUW+ghL1bJNbaFR1A==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.6.7.tgz",
+      "integrity": "sha512-PG6JwnPXxlMPXjMM924of5IO9xEmnJsSoDLdDZWz0p4Je6SjycRqWMezvc32jo4bY/niZUOH1hMa/Ux+w+YkWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.63",
-        "@aws-amplify/core": "6.7.3",
+        "@aws-amplify/api-rest": "4.0.64",
+        "@aws-amplify/core": "6.8.0",
         "@aws-amplify/data-schema": "^1.7.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.63",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.63.tgz",
-      "integrity": "sha512-Ihco8qhq5C8rkP8uttI6RmeG08upvsmzWVvDGXU7kScqQ6xd7PDGR1P2wRd+34ja8VxVnw1Ep0OG6m57m2ukpQ==",
+      "version": "4.0.64",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.64.tgz",
+      "integrity": "sha512-PrJbx1FEjf3UIOf8fcptwBGhCBRhk8R38Cut5eflbdlDdPbOPjvogGDs5KMJg6/dBkWYLftGSyBLOqOoMk6F6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.8.3.tgz",
-      "integrity": "sha512-JJHIy4am1t5rsj5SJJmXHEkLEriHeX/D/jgqX4dx54/r+hPUca1ZDep1xkNnJ2sIEkO+zMUMNxz2ynfhJRpM9g==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.9.0.tgz",
+      "integrity": "sha512-zJkscexjrANUr8FcC7rGKcZ/XivAE8E8b/0jlNVwz029stTvRV/paFYHIKsw4Lil0A0jsogJX94RthSJVZ3PZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.7.3.tgz",
-      "integrity": "sha512-OJ2p96qhkEg90lvB80yNOnTjFcOPL9HuRqD8yCIRW85abVS3SAFbb2cY0UjKXpS83oyoJlicLPlk0ETvjFj1ig==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.8.0.tgz",
+      "integrity": "sha512-1gnemNLMN0on0cxoIfqlICL2ebPLa4OGbFb2mhkdJC9Jx6xCHUV1lhvQcrHRqxAkIsQnKe8viHV2QotrTKzzkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.17.1.tgz",
-      "integrity": "sha512-920ZQfu0aYh/7tWOi3ddbZyHpuaKvQjfhL/+5QtTffipVhaDU/9MFTbr4o6SuL3FXqw12brP0N0AdXlB/aHpTg==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.17.2.tgz",
+      "integrity": "sha512-6BCO4JKIo+UZPVucrUVLzqGq6MpQwmba+EyaEbAWig3MIVIlaL6QDbJ54uhSKDANNYiTc+wLdklYzix8FITA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
@@ -260,12 +260,12 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.65",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.65.tgz",
-      "integrity": "sha512-nhgH8ft/qQWSdO2ePGVHm0bNDKVawzrwZ1uVmYh8En2RHUzCY79aW7tOqnBIENGsG0NlH2Ed6SxhC34hS1wkVw==",
+      "version": "5.0.66",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.66.tgz",
+      "integrity": "sha512-2d0lD//erzg+c2DsttWbi50gT1jWZmseKXoXr0ZIjaexEz/jpgBj5ZwTrQkMYDdmr3UUVkOvdbr2sLS0vZpjQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api": "6.1.8",
+        "@aws-amplify/api": "6.1.9",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.63",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.63.tgz",
-      "integrity": "sha512-40qockSu030+GPFWhgvALMMzpOnJSLQaJ7grPWQScLPRoqIzyOZNRhNCvsE8EmzgMpCjgbqrvpLxYnRtsio5Og==",
+      "version": "2.0.64",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.64.tgz",
+      "integrity": "sha512-pSR8GX4xSM9FiNL6XhJT3AKUlyzmUJVOTLnXb7FD+j4jC1RaTSKJbLlLIFtOIqMCqSeA7P76OMmFqE4+lujtvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.7.4.tgz",
-      "integrity": "sha512-WOjbiNrrEVrrrf/ftNN9Y/QhFSULT/pm5DfvRXtziCDRL5U2vvBihjqn+YAc+9JDbaKn7UXlgteEQ8c+XPeK1Q==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.7.5.tgz",
+      "integrity": "sha512-eN0io+mwfDDEqd29EeoCKivvEt0tH/rjF8WBKqWzX1PEQr4ledt5MA2gz6yFwxwGRYNY2KAr2lpzMSa4RCIqKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -3225,13 +3225,13 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@dual-bundle/import-meta-resolve": {
@@ -3823,13 +3823,13 @@
       }
     },
     "node_modules/@gbraver-burst-network/browser-sdk": {
-      "version": "1.16.12",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.16.12.tgz",
-      "integrity": "sha512-JhEoJ525o3eCL/icWrHUORUyaKXcNvtCjRsNqR8cLjL46oVHVuyMM5rAa6hELPOavWDddR/LinSgcQ3quNawqw==",
+      "version": "1.16.13",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.16.13.tgz",
+      "integrity": "sha512-+eiDksHn46CNDhMjDop28NViij8+gNKi/js9J0V/S3coBzqeHm+0SkNhIGk748EZzETWUUp+Y+l8/vfnFk3CAw==",
       "license": "MIT",
       "dependencies": {
-        "aws-amplify": "^6.10.3",
-        "gbraver-burst-core": "^1.33.1",
+        "aws-amplify": "^6.11.0",
+        "gbraver-burst-core": "^1.34.1",
         "rxjs": "^7.8.1",
         "zod": "^3.24.1"
       }
@@ -5321,9 +5321,9 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
-      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.6.tgz",
+      "integrity": "sha512-WAqzyulvvSKrT5c6VrQelgNVNNO7BlTQW9Z+s9tcG6G5CaBS1YBpPtT3VuhXLQbewSiGi7oXQROwpw26EG9PLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^2.5.5",
@@ -5340,15 +5340,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
-      "integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
+      "version": "3.0.31",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.31.tgz",
+      "integrity": "sha512-yq9wawrJLYHAYFpChLujxRN4My+SiKXvZk9Ml/CvTdRSA8ew+hvuR5LT+mjSlSBv3c4XJrkN8CWegkBaeD0Vrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.12",
         "@smithy/protocol-http": "^4.1.8",
         "@smithy/service-error-classification": "^3.0.11",
-        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/smithy-client": "^3.5.1",
         "@smithy/types": "^3.7.2",
         "@smithy/util-middleware": "^3.0.11",
         "@smithy/util-retry": "^3.0.11",
@@ -5552,13 +5552,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
-      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.1.tgz",
+      "integrity": "sha512-PmjskH4Os1Eh3rd5vSsa5uVelZ4DRu+N5CBEgb9AT96hQSJGWSEb6pGxKV/PtKQSIp9ft3+KvnT8ViMKaguzgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^2.5.5",
-        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-endpoint": "^3.2.6",
         "@smithy/middleware-stack": "^3.0.11",
         "@smithy/protocol-http": "^4.1.8",
         "@smithy/types": "^3.7.2",
@@ -5666,13 +5666,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
-      "integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
+      "version": "3.0.31",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.31.tgz",
+      "integrity": "sha512-eO+zkbqrPnmsagqzrmF7IJrCoU2wTQXWVYxMPqA9Oue55kw9WEvhyuw2XQzTVTCRcYsg6KgmV3YYhLlWQJfK1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/smithy-client": "^3.5.1",
         "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -5682,16 +5682,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
-      "integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
+      "version": "3.0.31",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.31.tgz",
+      "integrity": "sha512-0/nJfpSpbGZOs6qs42wCe2TdjobbnnD4a3YUUlvTXSQqLy4qa63luDaV04hGvqSHP7wQ7/WGehbvHkDhMZd1MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.13",
         "@smithy/credential-provider-imds": "^3.2.8",
         "@smithy/node-config-provider": "^3.1.12",
         "@smithy/property-provider": "^3.1.11",
-        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/smithy-client": "^3.5.1",
         "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
@@ -6657,17 +6657,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
-      "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
+      "integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/type-utils": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/type-utils": "8.18.1",
+        "@typescript-eslint/utils": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -6687,16 +6687,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
-      "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
+      "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
       "dev": true,
-      "license": "MITClause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6712,14 +6712,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
-      "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
+      "integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0"
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6730,14 +6730,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
-      "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
+      "integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.1",
+        "@typescript-eslint/utils": "8.18.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -6754,9 +6754,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
-      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
+      "integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6768,14 +6768,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
-      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
+      "integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/visitor-keys": "8.18.0",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/visitor-keys": "8.18.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -6821,16 +6821,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
-      "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
+      "integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.0",
-        "@typescript-eslint/types": "8.18.0",
-        "@typescript-eslint/typescript-estree": "8.18.0"
+        "@typescript-eslint/scope-manager": "8.18.1",
+        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.18.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6845,13 +6845,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
-      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
+      "integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/types": "8.18.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -7016,45 +7016,45 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
-      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
-      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
-      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
@@ -7428,18 +7428,18 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.10.3.tgz",
-      "integrity": "sha512-HJHKZsZK4e+EM6JU3N4jEsQN8Bwfks4FcONq3wnoc0X1KY/1LipslZ01Z9knR3F1EJEmM9wM8lrBhNyzYSg7Sw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.11.0.tgz",
+      "integrity": "sha512-CdX31Drrbk1i3QhpqCAAguf6OwPg2OHTa5g0wnxksRTjGdGKNLGaJCl65fcy3qG+LMh5Sjr55JJ6aO8wXYbvQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.63",
-        "@aws-amplify/api": "6.1.8",
-        "@aws-amplify/auth": "6.8.3",
-        "@aws-amplify/core": "6.7.3",
-        "@aws-amplify/datastore": "5.0.65",
-        "@aws-amplify/notifications": "2.0.63",
-        "@aws-amplify/storage": "6.7.4",
+        "@aws-amplify/analytics": "7.0.64",
+        "@aws-amplify/api": "6.1.9",
+        "@aws-amplify/auth": "6.9.0",
+        "@aws-amplify/core": "6.8.0",
+        "@aws-amplify/datastore": "5.0.66",
+        "@aws-amplify/notifications": "2.0.64",
+        "@aws-amplify/storage": "6.7.5",
         "tslib": "^2.5.0"
       }
     },
@@ -9435,9 +9435,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9741,9 +9741,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
-      "integrity": "sha512-rLu1s1Wf96TgUUxSw6loVIkNtUjq1Re7A9QdCCHSohnvXEBAjuL420h0T/fMmkQlNsQP2GhQzEUpYHPfxBkvYQ==",
+      "version": "28.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.10.0.tgz",
+      "integrity": "sha512-hyMWUxkBH99HpXT3p8hc7REbEZK3D+nk8vHXGgpB+XXsi0gO4PxMSP+pjfUzb67GnV9yawV9a53eUmcde1CCZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10115,9 +10115,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
       "funding": [
         {
           "type": "github",
@@ -10584,9 +10584,9 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.33.1",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.33.1.tgz",
-      "integrity": "sha512-jZ15ZrIhuxM0+ZgJJ0+GiPLvz0G3NP5mDuw0ObyUZEWaT6w7i9Em6fHmKShddaJRsiAShiLtd43fQCRSZNj81A==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.34.1.tgz",
+      "integrity": "sha512-vdCy0m2hnf2Oxza39WsOxxQ0qR9v4PQz/kSxeslctm5nW+MpoM4M1k7dej7ud34bQWuQ+3XaD7zspzgkbAjoPg==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.1",
@@ -10816,10 +10816,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.13.0.tgz",
-      "integrity": "sha512-49TewVEz0UxZjr1WYYsWpPrhyC/B/pA8Bq0fUmet2n+eR7yn0IvNzNaoBwnK6mdkzcN+se7Ez9zUgULTz2QH4g==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -18498,15 +18499,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.0.tgz",
-      "integrity": "sha512-Xq2rRjn6tzVpAyHr3+nmSg1/9k9aIHnJ2iZeOH7cfGOWqTkXTm3kwpQglEuLGdNrYvPF+2gtAs+/KF5rjVo+WQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.1.tgz",
+      "integrity": "sha512-Mlaw6yxuaDEPQvb/2Qwu3/TfgeBHy9iTJ3mTwe7OvpPmF6KPQjVOfGyEJpPv6Ez2C34OODChhXrzYw/9phI0MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.18.0",
-        "@typescript-eslint/parser": "8.18.0",
-        "@typescript-eslint/utils": "8.18.0"
+        "@typescript-eslint/eslint-plugin": "8.18.1",
+        "@typescript-eslint/parser": "8.18.1",
+        "@typescript-eslint/utils": "8.18.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -18880,59 +18881,46 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
-      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.1.1",
-        "@webpack-cli/info": "^2.0.2",
-        "@webpack-cli/serve": "^2.0.5",
+        "@discoveryjs/json-ext": "^0.6.1",
+        "@webpack-cli/configtest": "^3.0.1",
+        "@webpack-cli/info": "^3.0.1",
+        "@webpack-cli/serve": "^3.0.1",
         "colorette": "^2.0.14",
-        "commander": "^10.0.1",
+        "commander": "^12.1.0",
         "cross-spawn": "^7.0.3",
-        "envinfo": "^7.7.3",
+        "envinfo": "^7.14.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
-        "webpack-merge": "^5.7.3"
+        "webpack-merge": "^6.0.1"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "5.x.x"
+        "webpack": "^5.82.0"
       },
       "peerDependenciesMeta": {
-        "@webpack-cli/generators": {
-          "optional": true
-        },
         "webpack-bundle-analyzer": {
           "optional": true
         },
         "webpack-dev-server": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -19094,18 +19082,18 @@
       }
     },
     "node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
+        "wildcard": "^2.0.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.16.12",
+    "@gbraver-burst-network/browser-sdk": "1.16.13",
     "@tweenjs/tween.js": "^25.0.0",
-    "gbraver-burst-core": "1.33.1",
+    "gbraver-burst-core": "1.34.1",
     "handlebars": "^4.7.8",
     "howler": "^2.2.4",
     "jsqr": "^1.4.0",
@@ -46,10 +46,10 @@
     "dependency-cruiser": "^16.8.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.17.0",
-    "eslint-plugin-jest": "^28.9.0",
+    "eslint-plugin-jest": "^28.10.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "glob": "^11.0.0",
-    "globals": "^15.13.0",
+    "globals": "^15.14.0",
     "handlebars-loader": "^1.7.3",
     "html-webpack-plugin": "^5.6.3",
     "http-server": "^14.1.1",
@@ -72,9 +72,9 @@
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
-    "typescript-eslint": "^8.18.0",
+    "typescript-eslint": "^8.18.1",
     "webpack": "^5.97.1",
-    "webpack-cli": "^5.1.4",
+    "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.0"
   },
   "engines": {


### PR DESCRIPTION
This pull request includes updates to several dependencies in the `package.json` file to ensure the project uses the latest versions. The most important changes include updating the `@gbraver-burst-network/browser-sdk` and `gbraver-burst-core` dependencies, as well as several development dependencies.

Dependency updates:

* Updated `@gbraver-burst-network/browser-sdk` from version `1.16.12` to `1.16.13`.
* Updated `gbraver-burst-core` from version `1.33.1` to `1.34.1`.

Development dependency updates:

* Updated `eslint-plugin-jest` from version `28.9.0` to `28.10.0`.
* Updated `globals` from version `15.13.0` to `15.14.0`.
* Updated `typescript-eslint` from version `8.18.0` to `8.18.1`.
* Updated `webpack-cli` from version `5.1.4` to `6.0.1`.