### PR TITLE
グランドーザのバーストテキストを修正

### DIFF
--- a/src/js/game-description/burst-detail.ts
+++ b/src/js/game-description/burst-detail.ts
@@ -77,7 +77,7 @@ function forceTurnEndDetail(burst: ForceTurnEnd): string[] {
   return [
     `バッテリーを${burst.recoverBattery}回復する。`,
     `現在のターンを終了し、バッテリー回復なしで自分ターンを開始する。`,
-    `この効果でターン終了した場合、すべてのプレイヤーは「ターン終了時に発動する効果」が無効となる。`,
+    `この効果でターン終了した場合、「ターン終了時に発動する効果」は発動しない。`,
   ];
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `src/js/game-description/burst-detail.ts` file. The change updates the wording of a game effect description for clarity.

* [`src/js/game-description/burst-detail.ts`](diffhunk://#diff-117f569ff09b016b8bd1b96f449ae08e92a53827c8a27f8418d1b56eb423f150L80-R80): Modified the description of the effect when a turn ends to clarify that "end of turn" effects do not activate.