### PR TITLE
負けイベントのフラグを追加した

### DIFF
--- a/src/js/game/episodes/battery-system-tutorial.ts
+++ b/src/js/game/episodes/battery-system-tutorial.ts
@@ -29,4 +29,5 @@ export const batterySystemTutorial: Episode = {
   npc: batterySystemTutorialNPC(),
   event: createBatterySystemTutorialEvent,
   bgm: SOUND_IDS.TUTORIAL_BGM,
+  isLosingEvent: false,
 };

--- a/src/js/game/episodes/burst-tutorial.ts
+++ b/src/js/game/episodes/burst-tutorial.ts
@@ -28,4 +28,5 @@ export const burstTutorial: Episode = {
   npc: burstTutorialNPC(),
   event: createBurstTutorialEvent,
   bgm: SOUND_IDS.BATTLE_BGM_03,
+  isLosingEvent: false,
 };

--- a/src/js/game/episodes/confrontation-two-braver.ts
+++ b/src/js/game/episodes/confrontation-two-braver.ts
@@ -28,4 +28,5 @@ export const confrontationTwoBraver: Episode = {
   npc: genesisBraverNPC(),
   event: () => createConfrontationTwoBraverEvent(),
   bgm: SOUND_IDS.YUUYA_BATTLE,
+  isLosingEvent: true,
 };

--- a/src/js/game/episodes/episode.ts
+++ b/src/js/game/episodes/episode.ts
@@ -45,6 +45,8 @@ export type Episode = {
   player: Player;
   /** 再生するBGMのID */
   bgm: SoundId;
+  /** 負けイベントか否か、trueで負けイベント */
+  isLosingEvent: boolean;
   /**
    * カスタムバトルイベント生成関数、カスタムバトルイベントは状態を持つので都度生成する
    * @param resources リソース管理オブジェクト

--- a/src/js/game/episodes/pilot-skill-tutorial-01.ts
+++ b/src/js/game/episodes/pilot-skill-tutorial-01.ts
@@ -29,4 +29,5 @@ export const pilotSkillTutorial01: Episode = {
   npc: pilotSkillTutorialNPC(),
   event: createPilotSkillTutorial01Event,
   bgm: SOUND_IDS.BATTLE_BGM_01,
+  isLosingEvent: true,
 };

--- a/src/js/game/episodes/pilot-skill-tutorial-02.ts
+++ b/src/js/game/episodes/pilot-skill-tutorial-02.ts
@@ -28,4 +28,5 @@ export const pilotSkillTutorial02: Episode = {
   npc: pilotSkillTutorialNPC(),
   event: createPilotSkillTutorial02Event,
   bgm: SOUND_IDS.GAI_BATTLE,
+  isLosingEvent: false,
 };

--- a/src/js/game/episodes/prince-of-fallen-sun.ts
+++ b/src/js/game/episodes/prince-of-fallen-sun.ts
@@ -29,4 +29,5 @@ export const PrinceOfFallenSun: Episode = {
   npc: neoLandozerNPCForPrinceOfFallenSun(),
   event: () => createPrinceOfFallenSun(),
   bgm: SOUND_IDS.GAI_BATTLE,
+  isLosingEvent: false,
 };

--- a/src/js/game/episodes/queen-of-tragedy.ts
+++ b/src/js/game/episodes/queen-of-tragedy.ts
@@ -30,4 +30,5 @@ export const QueenOfTragedy: Episode = {
   npc: wingDozerNPCForQueenOfTragedy(),
   event: () => createQueenOfTragedy(),
   bgm: SOUND_IDS.QUEEN_OF_TRAGEDY,
+  isLosingEvent: false,
 };

--- a/src/js/game/episodes/zero-defense.ts
+++ b/src/js/game/episodes/zero-defense.ts
@@ -28,4 +28,5 @@ export const zeroDefenseTutorial: Episode = {
   npc: zeroDefenseTutorialNPC(),
   event: createZeroDefenseTutorialEvent,
   bgm: SOUND_IDS.BATTLE_BGM_01,
+  isLosingEvent: false,
 };


### PR DESCRIPTION
This pull request introduces a new boolean property `isLosingEvent` to the `Episode` type in the game, which indicates whether an episode is a losing event. Corresponding updates have been made to various episode files to include this new property.

### Introduction of `isLosingEvent` property:

* [`src/js/game/episodes/episode.ts`](diffhunk://#diff-cadcf28e688760b130612565f07b057858ed6e9bcf54541f09ffab5d93325fdeR48-R49): Added the `isLosingEvent` boolean property to the `Episode` type.

### Updates to individual episodes:

* [`src/js/game/episodes/battery-system-tutorial.ts`](diffhunk://#diff-16690fdbba8932a9719e16baa8db86d876e732c811dc8f15d241dc2b4a13e642R32): Set `isLosingEvent` to `false`.
* [`src/js/game/episodes/burst-tutorial.ts`](diffhunk://#diff-2d8b28dff84f87b7f15c11e1d0e61c97615b8b6037b0cf423a505543814b768eR31): Set `isLosingEvent` to `false`.
* [`src/js/game/episodes/confrontation-two-braver.ts`](diffhunk://#diff-16ff8ce645842a67a0fd33e4f2ccdafe4385cae4448d82c42fb0acd25947d38fR31): Set `isLosingEvent` to `true`.
* [`src/js/game/episodes/pilot-skill-tutorial-01.ts`](diffhunk://#diff-8f93913d61ad6ee6f49e8349c0082a6dcebead9a84e71b7ddc886c58cc4a4586R32): Set `isLosingEvent` to `true`.
* [`src/js/game/episodes/pilot-skill-tutorial-02.ts`](diffhunk://#diff-7bfd9a8bcde3cbd1d641489daa1a4a39049f65ae33eb7865ced0b03cea524387R31): Set `isLosingEvent` to `false`.
* [`src/js/game/episodes/prince-of-fallen-sun.ts`](diffhunk://#diff-3e41362f128ad29c1e3f1daaa11d92476af80d066a7ddb1e223b7fca57039903R32): Set `isLosingEvent` to `false`.
* [`src/js/game/episodes/queen-of-tragedy.ts`](diffhunk://#diff-575b7346b9908749b710bb7bdd9d7d45ebabbc79520166c059b675ac8bb3ca17R33): Set `isLosingEvent` to `false`.
* [`src/js/game/episodes/zero-defense.ts`](diffhunk://#diff-b6ee93969b1ddb3ec82a520acd1996813939f40a582e7b837abfac07b7525732R31): Set `isLosingEvent` to `false`.