### PR TITLE
画面全体のパディングを調整

### DIFF
--- a/src/css/root-element.css
+++ b/src/css/root-element.css
@@ -6,10 +6,10 @@
   --safe-area-right: env(safe-area-inset-right);
   --safe-area-bottom: env(safe-area-inset-bottom);
   --safe-area-left: env(safe-area-inset-left);
-  --screen-padding-top: calc(var(--safe-area-top) + 1rem);
-  --screen-padding-left: calc(var(--safe-area-left) + 1rem);
-  --screen-padding-right: calc(var(--safe-area-right) + 1rem);
-  --screen-padding-bottom: calc(var(--safe-area-bottom) + 1rem);
+  --screen-padding-top: max(var(--safe-area-top), 1rem);
+  --screen-padding-left: max(var(--safe-area-left), 1rem);
+  --screen-padding-right: max(var(--safe-area-right), 1rem);
+  --screen-padding-bottom: max(var(--safe-area-bottom), 1rem);
 
   /** フォント */
   --font-color: rgb(240 240 240);


### PR DESCRIPTION
This pull request includes a small change to the `src/css/root-element.css` file. The change modifies the calculation of screen padding values to use the `max` function instead of `calc` for better handling of safe area insets.

Changes to screen padding values:

* [`src/css/root-element.css`](diffhunk://#diff-09f75675ea11f09c08ca69595e68e41a899e35e75ade295367a2016bd0c09faaL9-R12): Changed `--screen-padding-top`, `--screen-padding-left`, `--screen-padding-right`, and `--screen-padding-bottom` to use the `max` function instead of `calc` for improved safe area handling.