### PR TITLE
クレジットをタイトルの下に移動した

### DIFF
--- a/src/css/title.css
+++ b/src/css/title.css
@@ -26,8 +26,8 @@
 
 .title__account-controller {
   position: absolute;
-  top: max(var(--safe-area-top), var(--responsive-font-size) * 1);
-  right: max(var(--safe-area-right), var(--responsive-font-size) * 1);
+  top: var(--screen-padding-top);
+  right: var(--screen-padding-right);
 }
 
 .title__login {
@@ -117,8 +117,8 @@
 
 .title__help {
   position: absolute;
-  top: max(var(--safe-area-top), var(--responsive-font-size) * 1);
-  left: max(var(--safe-area-left), var(--responsive-font-size) * 1);
+  top: var(--screen-padding-top);
+  left: var(--screen-padding-left);
 }
 
 .title__help-icon {
@@ -186,17 +186,25 @@
   justify-content: flex-end;
   box-sizing: border-box;
   padding: var(--screen-padding-top) var(--screen-padding-right)
-    calc(var(--responsive-font-size) * 0.5) var(--screen-padding-left);
+    var(--screen-padding-bottom) var(--screen-padding-left);
 }
 
-.title__logo-container {
-  display: grid;
-  place-items: center;
+.title__title {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   flex: 1;
 }
 
 .title__logo {
   height: 35vh;
+}
+
+.title__copy-rights,
+.title__music {
+  font-size: calc(var(--responsive-font-size) * 0.8);
+  text-shadow: 1px 1px 2px #000;
 }
 
 .title__game-menu {
@@ -230,33 +238,4 @@
 
 .title__net-battle--invisible {
   display: none;
-}
-
-.title__footer {
-  left: 0;
-  bottom: 0;
-  box-sizing: border-box;
-  width: 100vw;
-  width: 100dvw;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: baseline;
-  font-size: var(--responsive-font-size);
-  background-color: rgb(10 10 10 / 80%);
-  padding: calc(var(--responsive-font-size) * 0.2)
-    max(var(--responsive-font-size), var(--safe-area-right))
-    max(calc(var(--responsive-font-size) * 0.2), var(--safe-area-bottom))
-    max(var(--responsive-font-size), var(--safe-area-left));
-}
-
-.title__copy-rights {
-  font-size: calc(var(--responsive-font-size) * 0.8);
-}
-
-.title__music {
-  font-size: calc(var(--responsive-font-size) * 0.8);
-  text-decoration: none;
-  color: var(--button-font-color);
-  margin-left: calc(var(--responsive-font-size) * 1.6);
 }

--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -66,8 +66,14 @@
   </div>
 </div>
 <div class="{{ROOT_CLASS}}__contents">
-  <div class="{{ROOT_CLASS}}__logo-container">
+  <div class="{{ROOT_CLASS}}__title">
     <img class="{{ROOT_CLASS}}__logo" alt="タイトルロゴ" data-id="{{ids.logo}}" />
+    <small class="{{ROOT_CLASS}}__copy-rights">
+      <span class="{{ROOT_CLASS}}__copy-rights-symbol">&copy;</span>
+      <span class="{{ROOT_CLASS}}__copy-rights-year">2022</span>
+      <span class="{{ROOT_CLASS}}__copy-rights-owner">Pegass85</span>
+    </small>
+    <small class="{{ROOT_CLASS}}__music">音楽 魔王魂</small>
   </div>
   <div class="{{ROOT_CLASS}}__game-menu">
     <button
@@ -87,12 +93,4 @@
       data-id="{{ids.tutorial}}"
     >ストーリー</button>
   </div>
-</div>
-<div class="{{ROOT_CLASS}}__footer">
-  <small class="{{ROOT_CLASS}}__copy-rights">
-    <span class="{{ROOT_CLASS}}__copy-rights-symbol">&copy;</span>
-    <span class="{{ROOT_CLASS}}__copy-rights-year">2022</span>
-    <span class="{{ROOT_CLASS}}__copy-rights-owner">Pegass85</span>
-  </small>
-  <small class="{{ROOT_CLASS}}__music">音楽 魔王魂</small>
 </div>


### PR DESCRIPTION
This pull request includes several changes to the layout and styling of the title screen in both the CSS and HTML template files. The most important changes involve updating the positioning logic, restructuring the HTML elements, and removing redundant CSS classes.

Improvements to positioning logic:

* [`src/css/title.css`](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L29-R30): Replaced the use of `max(var(--safe-area-*), var(--responsive-font-size) * 1)` with `var(--screen-padding-*)` for consistent padding across different elements. [[1]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L29-R30) [[2]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L120-R121)

Restructuring HTML elements:

* [`src/js/dom-scenes/title/dom/root-inner-html.hbs`](diffhunk://#diff-bf991384bfa8941df5e3ca15732d5604b5c7e54effeb1139b479ec95fc96e3c2L69-R76): Moved the copyright and music information inside the `title` container and removed the `footer` container. [[1]](diffhunk://#diff-bf991384bfa8941df5e3ca15732d5604b5c7e54effeb1139b479ec95fc96e3c2L69-R76) [[2]](diffhunk://#diff-bf991384bfa8941df5e3ca15732d5604b5c7e54effeb1139b479ec95fc96e3c2L91-L98)

Removal of redundant CSS classes:

* [`src/css/title.css`](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L234-L262): Removed the `.title__footer`, `.title__logo-container`, `.title__copy-rights`, and `.title__music` classes, consolidating their styles into the `.title__title` class. [[1]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L234-L262) [[2]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L189-R209)