### PR TITLE
エピソードセレクターを改善

### DIFF
--- a/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
@@ -1,14 +1,8 @@
 <div class="{{BLOCK}}__episode-detail">
   <div class="{{BLOCK}}__episode-title" data-id="episodeTitle"></div>
-  <div
-    class="{{BLOCK}}__episode-image-cut-container"
-    data-id="episodeImageCutContainer"
-  >
+  <div class="{{BLOCK}}__episode-image-cut-container" data-id="episodeImageCutContainer">
   </div>
-  <div
-    class="{{BLOCK}}__episode-introduction"
-    data-id="episodeIntroduction"
-  ></div>
+  <div class="{{BLOCK}}__episode-introduction" data-id="episodeIntroduction"></div>
 </div>
 <div class="{{BLOCK}}__selector">
   <div class="{{BLOCK}}__episode-type-tabs">

--- a/stories/episode-selector.stories.ts
+++ b/stories/episode-selector.stories.ts
@@ -1,8 +1,7 @@
 import { StoryFn } from "@storybook/html";
 
 import { EpisodeSelector } from "../src/js/dom-scenes/episode-selector";
-import { Episode } from "../src/js/dom-scenes/episode-selector/episode";
-import { PathIds } from "../src/js/resource/path/ids";
+import { EpisodesInDevelopment } from "../src/js/game/episodes";
 import { domStub } from "./stub/dom-stub";
 
 export default {
@@ -11,35 +10,9 @@ export default {
 
 /** シーン表示 */
 export const scene: StoryFn = domStub((params) => {
-  const episodes: Episode[] = [
-    {
-      id: "01",
-      type: "Episode",
-      number: "1",
-      title: "バッテリーシステム基礎",
-      introduction: "導入",
-      imageCutPathId: PathIds.IMAGE_CUT_BATTERY_SYSTEM,
-    },
-    {
-      id: "02",
-      type: "Episode",
-      number: "2",
-      title: "ゼロ防御は即死",
-      introduction: "導入",
-      imageCutPathId: PathIds.IMAGE_CUT_ZERO_DEFENSE,
-    },
-    {
-      id: "03",
-      type: "Episode",
-      number: "3",
-      title: "バーストで一発逆転",
-      introduction: "導入",
-      imageCutPathId: PathIds.IMAGE_CUT_BURST,
-    },
-  ];
   const scene = new EpisodeSelector({
     ...params,
-    episodes,
+    episodes: EpisodesInDevelopment,
   });
   scene.notifyPrev().subscribe(() => {
     console.log("prev");


### PR DESCRIPTION
This pull request includes changes to streamline the `episode-selector` component and improve the codebase by removing redundant code and simplifying imports. The most important changes include modifying the HTML structure to be more concise, updating storybook stories to use a centralized episodes data source, and cleaning up imports.

HTML structure improvements:

* [`src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs`](diffhunk://#diff-d57f37db0a27610f24055c0f158f73b6cc50c9951841d3bfc531767bf10967d2L3-R5): Simplified the HTML structure by removing unnecessary line breaks and consolidating the `div` tags.

Storybook stories updates:

* [`stories/episode-selector.stories.ts`](diffhunk://#diff-006b04d393585f4a2eb81fd733d5df00f043714511e9266c993eaf27f52f90d5L4-R4): Updated the import to use `EpisodesInDevelopment` from `src/js/game/episodes` instead of defining the episodes inline.
* [`stories/episode-selector.stories.ts`](diffhunk://#diff-006b04d393585f4a2eb81fd733d5df00f043714511e9266c993eaf27f52f90d5L14-R15): Replaced the inline episode definitions with `EpisodesInDevelopment` to streamline the story setup.