### PR TITLE
エピソードセレクタのレイアウトを調整した

### DIFF
--- a/src/css/episode-selector.css
+++ b/src/css/episode-selector.css
@@ -14,9 +14,10 @@
     padding: var(--screen-padding-top) var(--screen-padding-right)
       var(--screen-padding-bottom) var(--screen-padding-left);
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: minmax(calc(var(--responsive-font-size) * 7), 1fr) auto;
-    grid-gap: var(--gap);
+    grid-template:
+      "tabs     detail" auto
+      "episodes detail" 1fr / 1fr 1fr;
+    grid-gap: 0 var(--gap);
   }
 }
 
@@ -26,40 +27,13 @@
   }
 }
 
-.episode-selector__episode-detail {
-  grid-row: 1 / 3;
-  grid-column: 1;
-  border-radius: var(--button-border-radius);
-  box-sizing: border-box;
-  font-size: var(--responsive-font-size);
-  padding: calc(var(--responsive-font-size) * 0.5);
-  background-color: var(--sub-background-color);
-  overflow: auto;
-}
-
-.episode-selector__episode-title {
-  margin-bottom: calc(var(--responsive-font-size) * 1);
-  border-bottom: dashed 1px var(--font-color);
-  word-break: keep-all;
-  overflow-wrap: anywhere;
-}
-
-.episode-selector__episode-image-cut {
-  width: 100%;
-  border-radius: var(--button-border-radius);
-  filter: brightness(0.7);
-}
-
-.episode-selector__episode-image-cut--invisible {
-  display: none;
-}
-
 .episode-selector__selector {
   display: flex;
   flex-direction: column;
 }
 
 .episode-selector__episode-type-tabs {
+  grid-area: tabs;
   display: flex;
 }
 
@@ -90,9 +64,8 @@
 }
 
 .episode-selector__episodes {
+  grid-area: episodes;
   flex: 1;
-  grid-row: 1;
-  grid-column: 2;
   display: flex;
   flex-direction: column;
   z-index: var(--controllers-z-index);
@@ -102,11 +75,31 @@
   overflow-y: scroll;
 }
 
-.episode-selector__controllers {
-  grid-row: 2;
-  grid-column: 2;
-  display: flex;
-  gap: var(--gap);
+.episode-selector__episode-detail {
+  grid-area: detail;
+  border-radius: var(--button-border-radius);
+  box-sizing: border-box;
+  font-size: var(--responsive-font-size);
+  padding: calc(var(--responsive-font-size) * 0.5);
+  background-color: var(--sub-background-color);
+  overflow: auto;
+}
+
+.episode-selector__episode-title {
+  margin-bottom: calc(var(--responsive-font-size) * 1);
+  border-bottom: dashed 1px var(--font-color);
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.episode-selector__episode-image-cut {
+  width: 100%;
+  border-radius: var(--button-border-radius);
+  filter: brightness(0.7);
+}
+
+.episode-selector__episode-image-cut--invisible {
+  display: none;
 }
 
 .episode-selector__prev,

--- a/src/css/episode-selector.css
+++ b/src/css/episode-selector.css
@@ -30,6 +30,8 @@
 .episode-selector__selector {
   display: flex;
   flex-direction: column;
+  background-color: var(--sub-background-color);
+  padding: calc(var(--responsive-font-size) * 0.5);
 }
 
 .episode-selector__episode-type-tabs {
@@ -70,8 +72,6 @@
   flex-direction: column;
   z-index: var(--controllers-z-index);
   border-radius: 0 0 var(--button-border-radius) var(--button-border-radius);
-  background-color: var(--sub-background-color);
-  padding: calc(var(--responsive-font-size) * 0.5);
   overflow-y: scroll;
 }
 
@@ -104,12 +104,10 @@
 
 .episode-selector__prev,
 .episode-selector__play-episode {
-  flex: 1;
   min-height: calc(var(--responsive-font-size) * 3);
   font-size: var(--responsive-font-size);
   border-radius: var(--button-border-radius);
   color: var(--button-font-color);
-  box-shadow: var(--button-box-shadow);
   z-index: var(--controllers-z-index);
   word-break: keep-all;
   overflow-wrap: anywhere;

--- a/src/css/episode-selector.css
+++ b/src/css/episode-selector.css
@@ -76,20 +76,26 @@
 }
 
 .episode-selector__episode-detail {
+  display: flex;
+  flex-direction: column;
   grid-area: detail;
   border-radius: var(--button-border-radius);
   box-sizing: border-box;
   font-size: var(--responsive-font-size);
   padding: calc(var(--responsive-font-size) * 0.5);
   background-color: var(--sub-background-color);
-  overflow: auto;
 }
 
 .episode-selector__episode-title {
-  margin-bottom: calc(var(--responsive-font-size) * 1);
+  margin-bottom: calc(var(--responsive-font-size) * 0.5);
   border-bottom: dashed 1px var(--font-color);
   word-break: keep-all;
   overflow-wrap: anywhere;
+}
+
+.episode-selector__contents {
+  flex: 1;
+  overflow-y: scroll;
 }
 
 .episode-selector__episode-image-cut {

--- a/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
@@ -8,9 +8,10 @@
 </div>
 <div class="{{BLOCK}}__episode-detail">
   <div class="{{BLOCK}}__episode-title" data-id="episodeTitle"></div>
-  <div class="{{BLOCK}}__episode-image-cut-container" data-id="episodeImageCutContainer">
+  <div class="{{BLOCK}}__contents">
+    <div class="{{BLOCK}}__episode-image-cut-container" data-id="episodeImageCutContainer"></div>
+    <div class="{{BLOCK}}__episode-introduction" data-id="episodeIntroduction"></div>
   </div>
-  <div class="{{BLOCK}}__episode-introduction" data-id="episodeIntroduction"></div>
   <button class="{{BLOCK}}__play-episode" data-id="playButton">
     このエピソード<wbr />をプレイ
   </button>

--- a/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs
@@ -1,18 +1,16 @@
+<div class="{{BLOCK}}__episode-type-tabs">
+  <div class="{{EPISODE_TYPE_SELECTED}}" data-id="mainEpisodeTab">メイン</div>
+  <div class="{{EPISODE_TYPE}}" data-id="sideEpisodeTab">サイド</div>
+</div>
+<div class="{{BLOCK}}__selector">
+  <div class="{{BLOCK}}__episodes" data-id="episodes"></div>
+  <button class="{{BLOCK}}__prev" data-id="prevButton">戻る</button>
+</div>
 <div class="{{BLOCK}}__episode-detail">
   <div class="{{BLOCK}}__episode-title" data-id="episodeTitle"></div>
   <div class="{{BLOCK}}__episode-image-cut-container" data-id="episodeImageCutContainer">
   </div>
   <div class="{{BLOCK}}__episode-introduction" data-id="episodeIntroduction"></div>
-</div>
-<div class="{{BLOCK}}__selector">
-  <div class="{{BLOCK}}__episode-type-tabs">
-    <div class="{{EPISODE_TYPE_SELECTED}}" data-id="mainEpisodeTab">メイン</div>
-    <div class="{{EPISODE_TYPE}}" data-id="sideEpisodeTab">サイド</div>
-  </div>
-  <div class="{{BLOCK}}__episodes" data-id="episodes"></div>
-</div>
-<div class="{{BLOCK}}__controllers">
-  <button class="{{BLOCK}}__prev" data-id="prevButton">戻る</button>
   <button class="{{BLOCK}}__play-episode" data-id="playButton">
     このエピソード<wbr />をプレイ
   </button>


### PR DESCRIPTION
This pull request includes significant changes to the layout and structure of the `episode-selector` component in both the CSS and HTML files. The primary objective is to improve the grid layout and simplify the HTML structure.

### Layout and Structure Improvements:

* [`src/css/episode-selector.css`](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76L17-R20): Updated the grid layout to use named grid areas for better readability and maintainability. The new grid template specifies "tabs", "episodes", and "detail" areas.
* [`src/css/episode-selector.css`](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76L29-R38): Moved the styles for `.episode-selector__episode-detail`, `.episode-selector__episode-title`, and `.episode-selector__episode-image-cut` to a more appropriate location in the CSS file, and removed redundant styles. [[1]](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76L29-R38) [[2]](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76R69-L119)

### HTML Structure Simplification:

* [`src/js/dom-scenes/episode-selector/dom/root-inner-html.hbs`](diffhunk://#diff-d57f37db0a27610f24055c0f158f73b6cc50c9951841d3bfc531767bf10967d2L1-R14): Reorganized the HTML structure to match the new grid layout, ensuring that the "episode-detail" section is now a sibling of the "selector" section and includes a new "contents" div to wrap the image and introduction.