### PR TITLE
エピソードセレクタのスタイルを微調整

### DIFF
--- a/src/css/episode-selector.css
+++ b/src/css/episode-selector.css
@@ -32,6 +32,7 @@
   flex-direction: column;
   background-color: var(--sub-background-color);
   padding: calc(var(--responsive-font-size) * 0.5);
+  border-radius: 0 0 var(--button-border-radius) var(--button-border-radius);
 }
 
 .episode-selector__episode-type-tabs {
@@ -71,7 +72,6 @@
   display: flex;
   flex-direction: column;
   z-index: var(--controllers-z-index);
-  border-radius: 0 0 var(--button-border-radius) var(--button-border-radius);
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
This pull request includes changes to the `src/css/episode-selector.css` file to adjust the styling of the episode selector component. The main change involves modifying the border-radius property.

Styling adjustments:

* [`src/css/episode-selector.css`](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76R35): Added a border-radius to the `.episode-selector` class to round the bottom corners.
* [`src/css/episode-selector.css`](diffhunk://#diff-1741908a4f0c601b36ad7d7e0f8e387e99ec9ff867414ba3f81ba1afe65cbb76L74): Removed the border-radius from the `.episode-selector__episode-type-tabs` class to avoid redundant styling.