### PR TITLE
タイトル画面のボタン位置を調整

### DIFF
--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -38,8 +38,8 @@
   </div>
   <div class="{{ROOT_CLASS}}__game-menu">
     <button class="{{ROOT_CLASS}}__config" data-id="{{ids.config}}">設定</button>
-    <button class="{{ROOT_CLASS}}__arcade" data-id="{{ids.arcade}}">アーケード</button>
     <button class="{{netBattleClassName}}" data-id="{{ids.netBattle}}">ネット対戦</button>
+    <button class="{{ROOT_CLASS}}__arcade" data-id="{{ids.arcade}}">アーケード</button>
     <button class="{{ROOT_CLASS}}__story" data-id="{{ids.tutorial}}">ストーリー</button>
   </div>
 </div>


### PR DESCRIPTION
This pull request includes a small change to the `src/js/dom-scenes/title/dom/root-inner-html.hbs` file. The change reorders the "アーケード" button to appear after the "ネット対戦" button instead of before it.

* [`src/js/dom-scenes/title/dom/root-inner-html.hbs`](diffhunk://#diff-bf991384bfa8941df5e3ca15732d5604b5c7e54effeb1139b479ec95fc96e3c2L41-R42): Reordered the "アーケード" button to appear after the "ネット対戦" button.