### PR TITLE
ネット対戦セレクタダイアログを改善

### DIFF
--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
@@ -1,0 +1,16 @@
+<div class="{{ROOT_CLASS}}__background" data-id="{{ids.backGround}}"></div>
+<div class="{{ROOT_CLASS}}__dialog">
+  <img class="{{ROOT_CLASS}}__closer" alt="閉じる" src="{{closerPath}}" data-id="{{ids.closer}}" />
+  <button class="{{ROOT_CLASS}}__casual-match" alt="カジュアルマッチをする" data-id="{{ids.casualMatchButton}}">
+    <div class="{{ROOT_CLASS}}__casual-match-title">カジュアルマッチ</div>
+    <div class="{{ROOT_CLASS}}__casual-match-description">{{casualMatchDescription}}</div>
+  </button>
+  <button class="{{ROOT_CLASS}}__private-match-host" alt="プライベートマッチ（ホスト）をする" data-id="{{ids.privateMatchHostButton}}">
+    <div class="{{ROOT_CLASS}}__private-match-host-title">プライベートマッチ（ホスト）</div>
+    <div class="{{ROOT_CLASS}}__private-match-host-description">{{privateMatchHostDescription}}</div>
+  </button>
+  <button class="{{ROOT_CLASS}}__private-match-guest" alt="プライベートマッチ（ゲスト）をする" data-id="{{ids.privateMatchGuestButton}}">
+    <div class="{{ROOT_CLASS}}__private-match-guest-title">プライベートマッチ（ゲスト）</div>
+    <div class="{{ROOT_CLASS}}__private-match-guest-description">{{privateMatchGuestDescription}}</div>
+  </button>
+</div>

--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.ts
@@ -2,6 +2,7 @@ import { Resources } from "../../../resource";
 import { PathIds } from "../../../resource/path/ids";
 import { ROOT_CLASS } from "./class-name";
 import { DataIDs } from "./data-ids";
+import template from "./root-inner-html.hbs";
 
 /**
  * ルートHTML要素のinnerHTMLを生成する
@@ -18,22 +19,12 @@ export function rootInnerHTML(resources: Resources, ids: DataIDs): string {
     "プライベートマッチを開催します、ルームIDをゲストに共有してください";
   const privateMatchGuestDescription =
     "ホストから共有されたルームIDを入力して、対戦を開始します";
-  return `
-    <div class="${ROOT_CLASS}__background" data-id="${ids.backGround}"></div>
-    <div class="${ROOT_CLASS}__dialog">
-      <img class="${ROOT_CLASS}__closer" alt="閉じる" src="${closerPath}" data-id="${ids.closer}">
-      <button class="${ROOT_CLASS}__casual-match" alt="カジュアルマッチをする" data-id="${ids.casualMatchButton}">
-        <div class="${ROOT_CLASS}__casual-match-title">カジュアルマッチ</div>
-        <div class="${ROOT_CLASS}__casual-match-description">${casualMatchDescription}</div>
-      </button>
-      <button class="${ROOT_CLASS}__private-match-host" alt="プライベートマッチ（ホスト）をする" data-id="${ids.privateMatchHostButton}">
-        <div class="${ROOT_CLASS}__private-match-host-title">プライベートマッチ（ホスト）</div>
-        <div class="${ROOT_CLASS}__private-match-host-description">${privateMatchHostDescription}</div>
-      </button>
-      <button class="${ROOT_CLASS}__private-match-guest" alt="プライベートマッチ（ゲスト）をする" data-id="${ids.privateMatchGuestButton}">
-        <div class="${ROOT_CLASS}__private-match-guest-title">プライベートマッチ（ゲスト）</div>
-        <div class="${ROOT_CLASS}__private-match-guest-description">${privateMatchGuestDescription}</div>
-      </button>
-    </div>
-  `;
+  return template({
+    ROOT_CLASS,
+    ids,
+    closerPath,
+    casualMatchDescription,
+    privateMatchHostDescription,
+    privateMatchGuestDescription,
+  });
 }


### PR DESCRIPTION
This pull request includes changes to the `net-battle-selector` component to improve its maintainability by using a Handlebars template for generating the HTML structure. The changes involve moving the HTML structure to a Handlebars file and updating the TypeScript file to use this template.

Improvements to HTML structure generation:

* [`src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs`](diffhunk://#diff-6bde011a6799fe138fe0907b12b00b39cae309e5a04a7f1943bdacce178d5a52R1-R16): Added a new Handlebars template file to define the HTML structure for the net battle selector dialog.

Updates to TypeScript file:

* [`src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.ts`](diffhunk://#diff-e72af9a2b3d847bcd5f17014efda67514db8ec7dbad3f68a293d1cddbda90fcaR5): Imported the new Handlebars template and updated the `rootInnerHTML` function to use this template instead of a hardcoded string. [[1]](diffhunk://#diff-e72af9a2b3d847bcd5f17014efda67514db8ec7dbad3f68a293d1cddbda90fcaR5) [[2]](diffhunk://#diff-e72af9a2b3d847bcd5f17014efda67514db8ec7dbad3f68a293d1cddbda90fcaL21-R29)