### PR TITLE
ネットバトルセレクタのボタンスタイルを調整

### DIFF
--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -4,9 +4,9 @@
   .net-battle-selector {
     --closer-width: 48px;
     --closer-height: 48px;
-    --casual-match-color: #00cc30;
+    --casual-match-background-color: #001a06;
     --casual-match-border: 2px solid #00cc30;
-    --private-match-color: #e666ff;
+    --private-match-background-color: #170a1a;
     --private-match-border: 2px solid #e666ff;
 
     display: block;
@@ -71,25 +71,22 @@
 
 .net-battle-selector__casual-match {
   grid-area: casual-match;
-  color: var(--casual-match-color);
-  font-weight: bold;
-  background-color: var(--sub-background-color);
+  color: var(--button-font-color);
+  background-color: var(--casual-match-background-color);
   border: var(--casual-match-border);
 }
 
 .net-battle-selector__private-match-host {
   grid-area: private-match-host;
-  color: var(--private-match-color);
-  font-weight: bold;
-  background-color: var(--sub-background-color);
+  color: var(--button-font-color);
+  background-color: var(--private-match-background-color);
   border: var(--private-match-border);
 }
 
 .net-battle-selector__private-match-guest {
   grid-area: private-match-guest;
-  color: var(--private-match-color);
-  font-weight: bold;
-  background-color: var(--sub-background-color);
+  color: var(--button-font-color);
+  background-color: var(--private-match-background-color);
   border: var(--private-match-border);
 }
 
@@ -107,6 +104,7 @@
 .net-battle-selector__private-match-host-title,
 .net-battle-selector__private-match-guest-title {
   font-size: calc(var(--responsive-font-size) * 1.2);
+  font-weight: bold;
   overflow-wrap: anywhere;
   word-break: normal;
   line-break: strict;

--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -6,8 +6,8 @@
     --closer-height: 48px;
     --casual-match-color: #00cc30;
     --casual-match-border: 2px solid #00cc30;
-    --private-match-color: #d500ff;
-    --private-match-border: 2px solid #d500ff;
+    --private-match-color: #e666ff;
+    --private-match-border: 2px solid #e666ff;
 
     display: block;
   }

--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -4,10 +4,10 @@
   .net-battle-selector {
     --closer-width: 48px;
     --closer-height: 48px;
-    --casual-match-color: #009924;
-    --casual-match-border: 2px solid #00330c;
-    --private-match-color: #8900ba;
-    --private-match-border: 2px solid #250033;
+    --casual-match-color: #00cc30;
+    --casual-match-border: 2px solid #00cc30;
+    --private-match-color: #d500ff;
+    --private-match-border: 2px solid #d500ff;
 
     display: block;
   }
@@ -71,19 +71,25 @@
 
 .net-battle-selector__casual-match {
   grid-area: casual-match;
-  background-color: var(--casual-match-color);
+  color: var(--casual-match-color);
+  font-weight: bold;
+  background-color: var(--sub-background-color);
   border: var(--casual-match-border);
 }
 
 .net-battle-selector__private-match-host {
   grid-area: private-match-host;
-  background-color: var(--private-match-color);
+  color: var(--private-match-color);
+  font-weight: bold;
+  background-color: var(--sub-background-color);
   border: var(--private-match-border);
 }
 
 .net-battle-selector__private-match-guest {
   grid-area: private-match-guest;
-  background-color: var(--private-match-color);
+  color: var(--private-match-color);
+  font-weight: bold;
+  background-color: var(--sub-background-color);
   border: var(--private-match-border);
 }
 
@@ -92,7 +98,6 @@
 .net-battle-selector__private-match-guest {
   min-height: calc(var(--responsive-font-size) * 1);
   border-radius: var(--button-border-radius);
-  color: var(--button-font-color);
   padding: calc(var(--responsive-font-size) * 1)
     calc(var(--responsive-font-size) * 2);
   text-align: left;
@@ -101,11 +106,12 @@
 .net-battle-selector__casual-match-title,
 .net-battle-selector__private-match-host-title,
 .net-battle-selector__private-match-guest-title {
-  font-size: calc(var(--responsive-font-size) * 1);
+  font-size: calc(var(--responsive-font-size) * 1.2);
 }
 
 .net-battle-selector__casual-match-description,
 .net-battle-selector__private-match-host-description,
 .net-battle-selector__private-match-guest-description {
+  color: var(--button-font-color);
   font-size: calc(var(--responsive-font-size) * 0.6);
 }

--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -55,8 +55,9 @@
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template:
+    "casual-match private-match-host" 1fr
+    "casual-match private-match-guest" 1fr / 1fr 1fr;
   grid-gap: calc(var(--responsive-font-size) * 0.3);
 }
 
@@ -69,22 +70,19 @@
 }
 
 .net-battle-selector__casual-match {
-  grid-column: 1;
-  grid-row: 1/3;
+  grid-area: casual-match;
   background-color: var(--casual-match-color);
   border: var(--casual-match-border);
 }
 
 .net-battle-selector__private-match-host {
-  grid-column: 2;
-  grid-row: 1;
+  grid-area: private-match-host;
   background-color: var(--private-match-color);
   border: var(--private-match-border);
 }
 
 .net-battle-selector__private-match-guest {
-  grid-column: 2;
-  grid-row: 2;
+  grid-area: private-match-guest;
   background-color: var(--private-match-color);
   border: var(--private-match-border);
 }

--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -4,6 +4,10 @@
   .net-battle-selector {
     --closer-width: 48px;
     --closer-height: 48px;
+    --casual-match-color: #009924;
+    --casual-match-border: 2px solid #00330c;
+    --private-match-color: #8900ba;
+    --private-match-border: 2px solid #250033;
 
     display: block;
   }
@@ -67,16 +71,22 @@
 .net-battle-selector__casual-match {
   grid-column: 1;
   grid-row: 1/3;
+  background-color: var(--casual-match-color);
+  border: var(--casual-match-border);
 }
 
 .net-battle-selector__private-match-host {
   grid-column: 2;
   grid-row: 1;
+  background-color: var(--private-match-color);
+  border: var(--private-match-border);
 }
 
 .net-battle-selector__private-match-guest {
   grid-column: 2;
   grid-row: 2;
+  background-color: var(--private-match-color);
+  border: var(--private-match-border);
 }
 
 .net-battle-selector__casual-match,
@@ -85,8 +95,6 @@
   min-height: calc(var(--responsive-font-size) * 1);
   border-radius: var(--button-border-radius);
   color: var(--button-font-color);
-  border: var(--sub-button-border);
-  background-color: var(--sub-button-background-color);
   padding: calc(var(--responsive-font-size) * 1)
     calc(var(--responsive-font-size) * 2);
   text-align: left;

--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -107,6 +107,9 @@
 .net-battle-selector__private-match-host-title,
 .net-battle-selector__private-match-guest-title {
   font-size: calc(var(--responsive-font-size) * 1.2);
+  overflow-wrap: anywhere;
+  word-break: normal;
+  line-break: strict;
 }
 
 .net-battle-selector__casual-match-description,

--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
@@ -6,11 +6,15 @@
     <div class="{{ROOT_CLASS}}__casual-match-description">{{casualMatchDescription}}</div>
   </button>
   <button class="{{ROOT_CLASS}}__private-match-host" alt="プライベートマッチ（ホスト）をする" data-id="{{ids.privateMatchHostButton}}">
-    <div class="{{ROOT_CLASS}}__private-match-host-title">プライベートマッチ（ホスト）</div>
+    <div class="{{ROOT_CLASS}}__private-match-host-title">
+      プライベートマッチ<wbr />（ホスト）
+    </div>
     <div class="{{ROOT_CLASS}}__private-match-host-description">{{privateMatchHostDescription}}</div>
   </button>
   <button class="{{ROOT_CLASS}}__private-match-guest" alt="プライベートマッチ（ゲスト）をする" data-id="{{ids.privateMatchGuestButton}}">
-    <div class="{{ROOT_CLASS}}__private-match-guest-title">プライベートマッチ（ゲスト）</div>
+    <div class="{{ROOT_CLASS}}__private-match-guest-title">
+      プライベートマッチ<wbr />（ゲスト）
+    </div>
     <div class="{{ROOT_CLASS}}__private-match-guest-description">{{privateMatchGuestDescription}}</div>
   </button>
 </div>


### PR DESCRIPTION
This pull request includes several changes to improve the styling and structure of the `net-battle-selector` component. The most important changes involve updating the CSS grid layout, adding new color variables for match types, and enhancing the title and description styling for better readability.

### CSS Improvements:

* [`src/css/net-battle-selector.css`](diffhunk://#diff-012a4476b20e2be6ebcd1b7adce5d59dff0fec91bb713a896f943ff07c0626b8R7-R10): Introduced new CSS variables for background colors and borders specific to casual and private matches.
* [`src/css/net-battle-selector.css`](diffhunk://#diff-012a4476b20e2be6ebcd1b7adce5d59dff0fec91bb713a896f943ff07c0626b8L54-R60): Updated the grid layout to use named grid areas for better organization and readability.
* [`src/css/net-battle-selector.css`](diffhunk://#diff-012a4476b20e2be6ebcd1b7adce5d59dff0fec91bb713a896f943ff07c0626b8L68-L89): Applied the new CSS variables to the respective match elements and adjusted their grid areas.
* [`src/css/net-battle-selector.css`](diffhunk://#diff-012a4476b20e2be6ebcd1b7adce5d59dff0fec91bb713a896f943ff07c0626b8L98-R116): Enhanced the styling of match titles and descriptions, including font size, weight, and text wrapping properties.

### HTML Template Update:

* [`src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs`](diffhunk://#diff-6bde011a6799fe138fe0907b12b00b39cae309e5a04a7f1943bdacce178d5a52L9-R17): Added word break opportunities (`<wbr>`) in the private match titles to improve text wrapping in narrow containers.