### PR TITLE
SE再生時にボリューム指定ができるようになった

### DIFF
--- a/src/js/se/se-player.ts
+++ b/src/js/se/se-player.ts
@@ -1,5 +1,11 @@
 import { SoundResource } from "../resource/sound/resource";
 
+/** 効果音再生オプション */
+type SEPlayerOptions = {
+  /** ボリューム */
+  volume?: number;
+};
+
 /** SE再生オブジェクト */
 export interface SEPlayer {
   /** 効果音のマスターボリューム、設定画面で入力したものをセットする */
@@ -8,8 +14,9 @@ export interface SEPlayer {
   /**
    * 効果音を再生する
    * @param sound 再生する効果音
+   * @param option 再生オプション
    */
-  play(sound: SoundResource): void;
+  play(sound: SoundResource, option?: SEPlayerOptions): void;
 }
 
 /** SE再生オブジェクトのシンプルな実装 */
@@ -25,8 +32,9 @@ class SimpleSEPlayer implements SEPlayer {
   }
 
   /** @override */
-  play(sound: SoundResource): void {
-    sound.sound.volume(this.volume * sound.volumeScale);
+  play(sound: SoundResource, option?: SEPlayerOptions): void {
+    const playVolume = option?.volume ?? 1;
+    sound.sound.volume(this.volume * sound.volumeScale * playVolume);
     sound.sound.play();
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `src/js/se/se-player.ts` file to introduce options for sound effect playback, specifically adding a volume control option. The most important changes include the addition of a new type for playback options, modifications to the `SEPlayer` interface to support these options, and updates to the `SimpleSEPlayer` class to handle the new volume option.

Enhancements to sound effect playback:

* [`src/js/se/se-player.ts`](diffhunk://#diff-b74e2081e44fb1c49fed44bc869e1b077e2f75f97542844473f737145c97a63dR3-R8): Added a new `SEPlayerOptions` type with a `volume` property to specify playback volume.
* [`src/js/se/se-player.ts`](diffhunk://#diff-b74e2081e44fb1c49fed44bc869e1b077e2f75f97542844473f737145c97a63dR17-R19): Modified the `SEPlayer` interface to include an optional `option` parameter in the `play` method.
* [`src/js/se/se-player.ts`](diffhunk://#diff-b74e2081e44fb1c49fed44bc869e1b077e2f75f97542844473f737145c97a63dL28-R37): Updated the `SimpleSEPlayer` class to use the new `volume` option when calculating the playback volume.