### PR TITLE
セリフを調整

### DIFF
--- a/src/js/custom-battle-events/confrontation-two-braver/stories/shinya-vistory.ts
+++ b/src/js/custom-battle-events/confrontation-two-braver/stories/shinya-vistory.ts
@@ -26,6 +26,6 @@ export async function shinyaVictory(props: CustomBattleEventProps) {
   activeRightMessageWindowWithFace(props, "Tsubasa");
   await scrollRightMessages(props, [["ツバサ", `「……ユウヤ`]]);
   await scrollRightMessages(props, [
-    [`負けた${wbr}ショックで 訳の${wbr}分からない${wbr}ことを」`],
+    [`負けた${wbr}ショックで メタい${wbr}ことを」`],
   ]);
 }


### PR DESCRIPTION
This pull request includes a small change to the `shinyaVictory` function in the `shinya-vistory.ts` file. The change updates a message string to replace a phrase with a more appropriate term.

* [`src/js/custom-battle-events/confrontation-two-braver/stories/shinya-vistory.ts`](diffhunk://#diff-9e65091a690a87a45e595e47a7a7ae4d5c71561d0a1c6ed3cf4aedd2344fcc06L29-R29): Updated the message string in the `shinyaVictory` function to replace "訳の分からないこと" with "メタいこと".