### PR TITLE
codeclimateカバレッジジョブを追加

### DIFF
--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -1,0 +1,30 @@
+name: code climate
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 22.x ]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - name: Test & publish code coverage
+      uses: paambaati/codeclimate-action@v9.0.0
+      env:
+        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      with:
+        coverageCommand: npm run coverage
+        debug: true

--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,17 @@ npm start
 ./clear-cdn.bash <CloudFrontのdistributionId>
 ```
 
+## GitHub Actions設定
+
+### Secrets設定
+[ここ](https://docs.github.com/ja/actions/security-guides/using-secrets-in-github-actions)を参考にGitHub ActionsのSecretsを設定する。
+以下が設定内容である。
+
+**secrets**
+| シークレット名 | 値 |
+|-------|----|
+| CC_TEST_REPORTER_ID | code climate reporter id |
+
 ## AWS環境設定
 
 ### 開発環境

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "code-format:src": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "code-format:storybook": "prettier --write stories",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:src": "depcruise src",
     "dependency-check:stories": "depcruise stories",


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for code coverage reporting with Code Climate, updates the `Readme.md` to include instructions for setting up GitHub Actions secrets, and adds a new npm script for running coverage tests. The most important changes are:

GitHub Actions workflow:

* [`.github/workflows/code-climate.yml`](diffhunk://#diff-bc73f6179757c7f37680c46140388c3e36484ba6408a41c6b267abee0eb92daaR1-R30): Added a new workflow named "code climate" that runs on pushes and pull requests to the `develop` branch. This workflow sets up Node.js, installs dependencies, and runs code coverage reporting using the `paambaati/codeclimate-action`.

Documentation update:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R58-R68): Added a section on setting up GitHub Actions secrets, including a table with the secret name `CC_TEST_REPORTER_ID` and its description.

Npm script addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R113): Added a new script `"coverage": "jest --coverage"` to generate code coverage reports using Jest.