### PR TITLE
シンブレイバーの攻撃アニメーションを改良した

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/attack.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/attack.ts
@@ -1,0 +1,36 @@
+import { CriticalHit, NormalHit } from "gbraver-burst-core";
+
+import { all } from "../../../../../../../animation/all";
+import { Animate } from "../../../../../../../animation/animate";
+import { delay } from "../../../../../../../animation/delay";
+import { toInitial } from "../../../../td-camera";
+import { focusToAttacker } from "./focus-to-attacker";
+import { ShinBraverBattle } from "./shin-braver-battle";
+
+/** attackが受け取れる戦闘結果 */
+type AttackResult = NormalHit | CriticalHit;
+
+/**
+ * 攻撃ヒット
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function attack(param: ShinBraverBattle<AttackResult>): Animate {
+  return all(
+    param.attackerSprite.charge().chain(delay(500)),
+    focusToAttacker(param.tdCamera, param.attackerSprite),
+  )
+    .chain(param.attackerSprite.straightPunch())
+    .chain(
+      all(
+        delay(1000)
+          .chain(param.attackerSprite.punchToStand())
+          .chain(delay(500)),
+        toInitial(param.tdCamera, 100),
+        param.defenderTD.damageIndicator.popUp(param.result.damage),
+        param.defenderSprite.knockBack(),
+        param.defenderTD.hitMark.shockWave.popUp(),
+        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
+      ),
+    );
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -1,0 +1,40 @@
+import { CriticalHit, Guard, NormalHit } from "gbraver-burst-core";
+
+import { all } from "../../../../../../../animation/all";
+import { Animate } from "../../../../../../../animation/animate";
+import { delay } from "../../../../../../../animation/delay";
+import { toInitial } from "../../../../td-camera";
+import { focusToAttacker } from "./focus-to-attacker";
+import { ShinBraverBattle } from "./shin-braver-battle";
+
+/** downが受け取れる戦闘結果 */
+type DownResult = NormalHit | CriticalHit | Guard;
+
+/**
+ * とどめ
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function down(param: ShinBraverBattle<DownResult>): Animate {
+  return all(
+    param.attackerSprite.charge().chain(delay(500)),
+    focusToAttacker(param.tdCamera, param.attackerSprite),
+  )
+    .chain(param.attackerSprite.straightPunch())
+    .chain(
+      all(
+        delay(1500)
+          .chain(param.attackerSprite.punchToStand())
+          .chain(delay(500)),
+        param.attackerHUD.resultIndicator
+          .slideIn()
+          .chain(delay(500))
+          .chain(param.attackerHUD.resultIndicator.moveToEdge()),
+        toInitial(param.tdCamera, 100),
+        param.defenderTD.damageIndicator.popUp(param.result.damage),
+        param.defenderSprite.down(),
+        param.defenderTD.hitMark.shockWave.popUp(),
+        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
+      ),
+    );
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/feint.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/feint.ts
@@ -1,0 +1,18 @@
+import { Feint } from "gbraver-burst-core";
+
+import { Animate } from "../../../../../../../animation/animate";
+import { delay, empty } from "../../../../../../../animation/delay";
+import { ShinBraverBattle } from "./shin-braver-battle";
+
+/**
+ * フェイント
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function feint(param: ShinBraverBattle<Feint>): Animate {
+  if (!param.result.isDefenderMoved) {
+    return empty();
+  }
+
+  return param.defenderSprite.avoid().chain(delay(500));
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/focus-to-attacker.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/focus-to-attacker.ts
@@ -1,0 +1,23 @@
+import { all } from "../../../../../../../animation/all";
+import { Animate } from "../../../../../../../animation/animate";
+import { ShinBraver } from "../../../../../../../game-object/armdozer/shin-braver/shin-braver";
+import { TDCamera } from "../../../../../../../game-object/camera/td";
+
+/**
+ * アタッカーにフォーカスを合わせる
+ * @param camera カメラ
+ * @param attacker スプライト
+ * @returns アニメーション
+ */
+export function focusToAttacker(
+  camera: TDCamera,
+  attacker: ShinBraver,
+): Animate {
+  const duration = 400;
+  const x = attacker.getObject3D().position.x * 0.6;
+  const z = "-30";
+  return all(
+    camera.move({ x, z }, duration),
+    camera.lookAt({ x, z }, duration),
+  );
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/guard.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/guard.ts
@@ -1,0 +1,29 @@
+import { Guard } from "gbraver-burst-core";
+
+import { all } from "../../../../../../../animation/all";
+import { Animate } from "../../../../../../../animation/animate";
+import { delay } from "../../../../../../../animation/delay";
+import { ShinBraverBattle } from "./shin-braver-battle";
+
+/**
+ * ガード
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function guard(param: ShinBraverBattle<Guard>): Animate {
+  return param.attackerSprite
+    .charge()
+    .chain(delay(500))
+    .chain(param.attackerSprite.straightPunch())
+    .chain(
+      all(
+        delay(1000)
+          .chain(param.attackerSprite.punchToStand())
+          .chain(delay(500)),
+        param.defenderTD.damageIndicator.popUp(param.result.damage),
+        param.defenderSprite.guard(),
+        param.defenderTD.hitMark.shockWave.popUp(),
+        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
+      ),
+    );
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
@@ -7,13 +7,13 @@ import type {
   NormalHit,
 } from "gbraver-burst-core";
 
-import { all } from "../../../../../../animation/all";
-import { Animate } from "../../../../../../animation/animate";
-import { delay, empty } from "../../../../../../animation/delay";
-import { ShinBraver } from "../../../../../../game-object/armdozer/shin-braver/shin-braver";
-import { TDCamera } from "../../../../../../game-object/camera/td";
-import { toInitial } from "../../../td-camera";
-import { BattleAnimationParamX } from "../animation-param";
+import { all } from "../../../../../../../animation/all";
+import { Animate } from "../../../../../../../animation/animate";
+import { delay, empty } from "../../../../../../../animation/delay";
+import { ShinBraver } from "../../../../../../../game-object/armdozer/shin-braver/shin-braver";
+import { TDCamera } from "../../../../../../../game-object/camera/td";
+import { toInitial } from "../../../../td-camera";
+import { BattleAnimationParamX } from "../../animation-param";
 
 /**
  * シンブレイバー 戦闘アニメーション パラメータ

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   BattleResult,
   CriticalHit,
   Feint,
@@ -7,148 +7,14 @@ import type {
   NormalHit,
 } from "gbraver-burst-core";
 
-import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
-import { delay, empty } from "../../../../../../../animation/delay";
-import { ShinBraver } from "../../../../../../../game-object/armdozer/shin-braver/shin-braver";
-import { TDCamera } from "../../../../../../../game-object/camera/td";
-import { toInitial } from "../../../../td-camera";
-import { BattleAnimationParamX } from "../../animation-param";
-
-/**
- * シンブレイバー 戦闘アニメーション パラメータ
- * @template RESULT 戦闘結果
- */
-export type ShinBraverBattle<RESULT extends BattleResult> =
-  BattleAnimationParamX<ShinBraver, RESULT>;
-
-/**
- * アタッカーにフォーカスを合わせる
- * @param camera カメラ
- * @param attacker スプライト
- * @returns アニメーション
- */
-function focusToAttacker(camera: TDCamera, attacker: ShinBraver): Animate {
-  const duration = 400;
-  const x = attacker.getObject3D().position.x * 0.6;
-  const z = "-30";
-  return all(
-    camera.move({ x, z }, duration),
-    camera.lookAt({ x, z }, duration),
-  );
-}
-
-/** attackが受け取れる戦闘結果 */
-type AttackResult = NormalHit | CriticalHit;
-
-/**
- * 攻撃ヒット
- * @param param パラメータ
- * @returns アニメーション
- */
-function attack(param: ShinBraverBattle<AttackResult>): Animate {
-  return all(
-    param.attackerSprite.charge().chain(delay(500)),
-    focusToAttacker(param.tdCamera, param.attackerSprite),
-  )
-    .chain(param.attackerSprite.straightPunch())
-    .chain(
-      all(
-        delay(1000)
-          .chain(param.attackerSprite.punchToStand())
-          .chain(delay(500)),
-        toInitial(param.tdCamera, 100),
-        param.defenderTD.damageIndicator.popUp(param.result.damage),
-        param.defenderSprite.knockBack(),
-        param.defenderTD.hitMark.shockWave.popUp(),
-        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
-      ),
-    );
-}
-
-/**
- * ガード
- * @param param パラメータ
- * @returns アニメーション
- */
-function guard(param: ShinBraverBattle<Guard>): Animate {
-  return param.attackerSprite
-    .charge()
-    .chain(delay(500))
-    .chain(param.attackerSprite.straightPunch())
-    .chain(
-      all(
-        delay(1000)
-          .chain(param.attackerSprite.punchToStand())
-          .chain(delay(500)),
-        param.defenderTD.damageIndicator.popUp(param.result.damage),
-        param.defenderSprite.guard(),
-        param.defenderTD.hitMark.shockWave.popUp(),
-        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
-      ),
-    );
-}
-
-/**
- * ミス
- * @param param パラメータ
- * @returns アニメーション
- */
-function miss(param: ShinBraverBattle<Miss>): Animate {
-  return param.attackerSprite
-    .charge()
-    .chain(delay(500))
-    .chain(param.attackerSprite.straightPunch())
-    .chain(param.defenderSprite.avoid())
-    .chain(delay(500))
-    .chain(param.attackerSprite.punchToStand())
-    .chain(delay(500));
-}
-
-/**
- * フェイント
- * @param param パラメータ
- * @returns アニメーション
- */
-function feint(param: ShinBraverBattle<Feint>): Animate {
-  if (!param.result.isDefenderMoved) {
-    return empty();
-  }
-
-  return param.defenderSprite.avoid().chain(delay(500));
-}
-
-/** downが受け取れる戦闘結果 */
-type DownResult = NormalHit | CriticalHit | Guard;
-
-/**
- * とどめ
- * @param param パラメータ
- * @returns アニメーション
- */
-function down(param: ShinBraverBattle<DownResult>): Animate {
-  return all(
-    param.attackerSprite.charge().chain(delay(500)),
-    focusToAttacker(param.tdCamera, param.attackerSprite),
-  )
-    .chain(param.attackerSprite.straightPunch())
-    .chain(
-      all(
-        delay(1500)
-          .chain(param.attackerSprite.punchToStand())
-          .chain(delay(500)),
-        param.attackerHUD.resultIndicator
-          .slideIn()
-          .chain(delay(500))
-          .chain(param.attackerHUD.resultIndicator.moveToEdge()),
-        toInitial(param.tdCamera, 100),
-        param.defenderTD.damageIndicator.popUp(param.result.damage),
-        param.defenderSprite.down(),
-        param.defenderTD.hitMark.shockWave.popUp(),
-        param.defenderHUD.gauge.hp(param.defenderState.armdozer.hp),
-      ),
-    );
-}
+import { empty } from "../../../../../../../animation/delay";
+import { attack } from "./attack";
+import { down } from "./down";
+import { feint } from "./feint";
+import { guard } from "./guard";
+import { miss } from "./miss";
+import { ShinBraverBattle } from "./shin-braver-battle";
 
 /**
  * シンブレイバーの攻撃アニメーション

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
@@ -1,11 +1,4 @@
-import {
-  BattleResult,
-  CriticalHit,
-  Feint,
-  Guard,
-  Miss,
-  NormalHit,
-} from "gbraver-burst-core";
+import { BattleResult } from "gbraver-burst-core";
 
 import { Animate } from "../../../../../../../animation/animate";
 import { empty } from "../../../../../../../animation/delay";
@@ -24,45 +17,26 @@ import { ShinBraverBattle } from "./shin-braver-battle";
 export function shinBraverAttack(
   param: ShinBraverBattle<BattleResult>,
 ): Animate {
-  if (param.isDeath && param.result.name === "NormalHit") {
-    const result: NormalHit = param.result;
+  let ret = empty();
+
+  const { result } = param;
+  if (param.isDeath && result.name === "NormalHit") {
+    ret = down({ ...param, result });
+  } else if (result.name === "NormalHit") {
+    ret = attack({ ...param, result });
+  } else if (param.isDeath && result.name === "CriticalHit") {
+    ret = down({ ...param, result });
+  } else if (result.name === "CriticalHit") {
+    ret = attack({ ...param, result });
+  } else if (param.isDeath && result.name === "Guard") {
     return down({ ...param, result });
-  }
-
-  if (param.result.name === "NormalHit") {
-    const result: NormalHit = param.result;
-    return attack({ ...param, result });
-  }
-
-  if (param.isDeath && param.result.name === "CriticalHit") {
-    const result: CriticalHit = param.result;
-    return down({ ...param, result });
-  }
-
-  if (param.result.name === "CriticalHit") {
-    const result: CriticalHit = param.result;
-    return attack({ ...param, result });
-  }
-
-  if (param.isDeath && param.result.name === "Guard") {
-    const result: Guard = param.result;
-    return down({ ...param, result });
-  }
-
-  if (param.result.name === "Guard") {
-    const result: Guard = param.result;
+  } else if (result.name === "Guard") {
     return guard({ ...param, result });
+  } else if (result.name === "Miss") {
+    ret = miss({ ...param, result });
+  } else if (result.name === "Feint") {
+    ret = feint({ ...param, result });
   }
 
-  if (param.result.name === "Miss") {
-    const result: Miss = param.result;
-    return miss({ ...param, result });
-  }
-
-  if (param.result.name === "Feint") {
-    const result: Feint = param.result;
-    return feint({ ...param, result });
-  }
-
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts
@@ -20,16 +20,17 @@ export function shinBraverAttack(
   let ret = empty();
 
   const { result } = param;
-  if (param.isDeath && result.name === "NormalHit") {
+  if (
+    param.isDeath &&
+    (result.name === "NormalHit" ||
+      result.name === "CriticalHit" ||
+      result.name === "Guard")
+  ) {
     ret = down({ ...param, result });
   } else if (result.name === "NormalHit") {
     ret = attack({ ...param, result });
-  } else if (param.isDeath && result.name === "CriticalHit") {
-    ret = down({ ...param, result });
   } else if (result.name === "CriticalHit") {
     ret = attack({ ...param, result });
-  } else if (param.isDeath && result.name === "Guard") {
-    return down({ ...param, result });
   } else if (result.name === "Guard") {
     return guard({ ...param, result });
   } else if (result.name === "Miss") {

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/miss.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/miss.ts
@@ -1,0 +1,21 @@
+import { Miss } from "gbraver-burst-core";
+
+import { Animate } from "../../../../../../../animation/animate";
+import { delay } from "../../../../../../../animation/delay";
+import { ShinBraverBattle } from "./shin-braver-battle";
+
+/**
+ * ミス
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function miss(param: ShinBraverBattle<Miss>): Animate {
+  return param.attackerSprite
+    .charge()
+    .chain(delay(500))
+    .chain(param.attackerSprite.straightPunch())
+    .chain(param.defenderSprite.avoid())
+    .chain(delay(500))
+    .chain(param.attackerSprite.punchToStand())
+    .chain(delay(500));
+}

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/shin-braver-battle.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/shin-braver-battle.ts
@@ -1,0 +1,11 @@
+import { BattleResult } from "gbraver-burst-core";
+
+import { ShinBraver } from "../../../../../../../game-object/armdozer/shin-braver/shin-braver";
+import { BattleAnimationParamX } from "../../animation-param";
+
+/**
+ * シンブレイバー 戦闘アニメーション パラメータ
+ * @template RESULT 戦闘結果
+ */
+export type ShinBraverBattle<RESULT extends BattleResult> =
+  BattleAnimationParamX<ShinBraver, RESULT>;


### PR DESCRIPTION
This pull request refactors the `shin-braver` attack animations in the `td-scenes` module by splitting the monolithic `shin-braver.ts` file into multiple smaller, more manageable files. The changes improve code organization and maintainability. The most important changes include the creation of new files for specific attack animations and helper functions.

Refactoring of `shin-braver` attack animations:

* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/attack.ts`](diffhunk://#diff-40863978738cc78fa0af99ba02bc7dae378697d03ff5684b144b6a431d57b2e2R1-R36): Added a new file for the `attack` animation function, which handles the animation sequence for a successful attack.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts`](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889R1-R40): Added a new file for the `down` animation function, which handles the animation sequence for a finishing move.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/feint.ts`](diffhunk://#diff-e3ce22876142297f5c59313ac06c3be28ed9d665d5cda8e052d26bfda6297d9eR1-R18): Added a new file for the `feint` animation function, which handles the animation sequence for a feint move.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/guard.ts`](diffhunk://#diff-4a16530aedc65a70c6f7a9af7deccec7abe892ed91543334b01321a9ad3a4ec9R1-R29): Added a new file for the `guard` animation function, which handles the animation sequence for a guard move.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/miss.ts`](diffhunk://#diff-baf8952fc2795dd11e2a721fc0603912d9836bf81500d215757996de1c2256acR1-R21): Added a new file for the `miss` animation function, which handles the animation sequence for a missed attack.

Helper functions and type definitions:

* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/focus-to-attacker.ts`](diffhunk://#diff-7d3858ab5d30489e1c45798208d5b727e690a87631edf595231e38bd55d48b9cR1-R23): Added a new file for the `focusToAttacker` helper function, which focuses the camera on the attacker during an animation.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/shin-braver-battle.ts`](diffhunk://#diff-e027ffe96ca75d2da45b87e45f611dc3eaec7b0243a2c78fe81e0b4d2b1feb1dR1-R11): Added a new file for the `ShinBraverBattle` type definition, which defines the parameters for `shin-braver` battle animations.
* [`src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/index.ts`](diffhunk://#diff-e5f2db21ab52807c3aa607589f2e7c0ff09ad0d1e8923f81a7e0ea7beec32733R1-R43): Added a new file for the `shinBraverAttack` function, which orchestrates the different attack animations based on the battle result.