### PR TITLE
npmパッケージ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "dependency-cruiser": "^16.9.0",
         "dotenv": "^16.4.7",
         "eslint": "^9.18.0",
-        "eslint-plugin-jest": "^28.10.0",
+        "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "glob": "^11.0.1",
         "globals": "^15.14.0",
@@ -9812,9 +9812,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.10.0.tgz",
-      "integrity": "sha512-hyMWUxkBH99HpXT3p8hc7REbEZK3D+nk8vHXGgpB+XXsi0gO4PxMSP+pjfUzb67GnV9yawV9a53eUmcde1CCZA==",
+      "version": "28.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dependency-cruiser": "^16.9.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.18.0",
-    "eslint-plugin-jest": "^28.10.0",
+    "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "glob": "^11.0.1",
     "globals": "^15.14.0",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file to upgrade the `eslint-plugin-jest` dependency version.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49): Upgraded `eslint-plugin-jest` from version `^28.10.0` to `^28.11.0`.