### PR TITLE
ドキュメントにCODE CLIMATEのテストレポーターIDの記載を追加した

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ npm start
 **secrets**
 | シークレット名 | 値 |
 |-------|----|
-| CC_TEST_REPORTER_ID | code climate reporter id |
+| CC_TEST_REPORTER_ID | CODE CLIMATEの[test reporter id](https://docs.codeclimate.com/docs/finding-your-test-coverage-token) |
 
 ## AWS環境設定
 


### PR DESCRIPTION
This pull request includes a change to the `Readme.md` file to improve the clarity of the `CC_TEST_REPORTER_ID` description.

Documentation update:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L68-R68): Updated the description of `CC_TEST_REPORTER_ID` to include a link to the Code Climate documentation for finding the test reporter ID.