### PR TITLE
ゲーム終了アニメをリファクタリングした

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over-param.ts
+++ b/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over-param.ts
@@ -6,23 +6,19 @@ import type { StateAnimationProps } from "../../state-animation-props";
 
 /**
  * ゲームオーバー アニメーションパラメータ
- *
- * @type TD_ARMDOZER 3Dレイヤー アームドーザ固有オブジェクト
+ * @param TD_ARMDOZER 3Dレイヤー アームドーザ固有オブジェクト
  */
 export type GameOverParamX<TD_ARMDOZER extends TDArmdozerObjects> = {
   winnerTdArmdozer: TD_ARMDOZER;
   tdCamera: TDCamera;
 };
 
-/**
- * ゲームオーバー アニメーションパラメータ
- */
+/** ゲームオーバー アニメーションパラメータ */
 export type GameOverParam = GameOverParamX<TDArmdozerObjects>;
 
 /**
  * ゲームオーバー アニメーションパラメータに変換する
  * 変換できない場合はnullを返す
- *
  * @param props 戦闘シーンプロパティ
  * @param gameOver ゲームオーバー情報
  * @returns 変換結果
@@ -30,18 +26,11 @@ export type GameOverParam = GameOverParamX<TDArmdozerObjects>;
 export function toGameOverParam(
   props: StateAnimationProps,
   gameOver: GameOver,
-): GameOverParam | null | undefined {
-  const winnerArmdozer = props.view.td.armdozers.find(
+): GameOverParam | null {
+  const winnerTdArmdozer = props.view.td.armdozers.find(
     (v) => v.playerId === gameOver.winner,
   );
-
-  if (!winnerArmdozer) {
-    return null;
-  }
-
-  const tdArmdozer: TDArmdozerObjects = winnerArmdozer;
-  return {
-    winnerTdArmdozer: tdArmdozer,
-    tdCamera: props.view.td.camera,
-  };
+  return winnerTdArmdozer
+    ? { winnerTdArmdozer, tdCamera: props.view.td.camera }
+    : null;
 }

--- a/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over-param.ts
+++ b/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over-param.ts
@@ -1,12 +1,12 @@
-import type { GameOver } from "gbraver-burst-core";
+import { GameOver } from "gbraver-burst-core";
 
 import { TDCamera } from "../../../../../../game-object/camera/td";
-import type { TDArmdozerObjects } from "../../../../view/td/armdozer-objects/armdozer-objects";
-import type { StateAnimationProps } from "../../state-animation-props";
+import { TDArmdozerObjects } from "../../../../view/td/armdozer-objects/armdozer-objects";
+import { StateAnimationProps } from "../../state-animation-props";
 
 /**
  * ゲームオーバー アニメーションパラメータ
- * @param TD_ARMDOZER 3Dレイヤー アームドーザ固有オブジェクト
+ * @template TD_ARMDOZER 3Dレイヤー アームドーザ固有オブジェクト
  */
 export type GameOverParamX<TD_ARMDOZER extends TDArmdozerObjects> = {
   winnerTdArmdozer: TD_ARMDOZER;

--- a/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over.ts
+++ b/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over.ts
@@ -5,42 +5,48 @@ import { LightningDozerTD } from "../../../../view/td/armdozer-objects/lightning
 import { NeoLandozerTD } from "../../../../view/td/armdozer-objects/neo-landozer";
 import { ShinBraverTD } from "../../../../view/td/armdozer-objects/shin-braver";
 import { WingDozerTD } from "../../../../view/td/armdozer-objects/wing-dozer";
-import type { GameOverParam } from "./game-over-param";
+import { toGameOverParam } from "./game-over-param";
 import { genesisBraverWin } from "./genesis-braver";
 import { lightningDozerWin } from "./lightning-dozer";
 import { neoLandozerWin } from "./neo-landozer";
 import { shinBraverWin } from "./shin-braver";
 import { wingDozerWin } from "./wing-dozer";
+import { StateAnimationProps } from "../../state-animation-props";
+import { GameEndX, GameOver, GameStateX } from "gbraver-burst-core";
 
 /**
  * ゲームオーバアニメーション
- *
- * @param param アニメーションパラメータ
+ * @param props 戦闘シーンプロパティ
+ * @param gameState ゲームの状態
  * @returns アニメーション
  */
-export function gameOverAnimation(param: GameOverParam): Animate {
-  if (param.winnerTdArmdozer instanceof ShinBraverTD) {
-    const winnerTdArmdozer: ShinBraverTD = param.winnerTdArmdozer;
+export function gameOverAnimation(
+  props: StateAnimationProps,
+  gameState: GameStateX<GameEndX<GameOver>>,
+): Animate {
+  const param = toGameOverParam(props, gameState.effect.result);
+  if (!param) {
+    return empty();
+  }
+
+  const { winnerTdArmdozer } = param;
+  if (winnerTdArmdozer instanceof ShinBraverTD) {
     return shinBraverWin({ ...param, winnerTdArmdozer });
   }
 
-  if (param.winnerTdArmdozer instanceof NeoLandozerTD) {
-    const winnerTdArmdozer: NeoLandozerTD = param.winnerTdArmdozer;
+  if (winnerTdArmdozer instanceof NeoLandozerTD) {
     return neoLandozerWin({ ...param, winnerTdArmdozer });
   }
 
-  if (param.winnerTdArmdozer instanceof LightningDozerTD) {
-    const winnerTdArmdozer: LightningDozerTD = param.winnerTdArmdozer;
+  if (winnerTdArmdozer instanceof LightningDozerTD) {
     return lightningDozerWin({ ...param, winnerTdArmdozer });
   }
 
-  if (param.winnerTdArmdozer instanceof WingDozerTD) {
-    const winnerTdArmdozer: WingDozerTD = param.winnerTdArmdozer;
+  if (winnerTdArmdozer instanceof WingDozerTD) {
     return wingDozerWin({ ...param, winnerTdArmdozer });
   }
 
-  if (param.winnerTdArmdozer instanceof GenesisBraverTD) {
-    const winnerTdArmdozer: GenesisBraverTD = param.winnerTdArmdozer;
+  if (winnerTdArmdozer instanceof GenesisBraverTD) {
     return genesisBraverWin({ ...param, winnerTdArmdozer });
   }
 

--- a/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over.ts
+++ b/src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over.ts
@@ -1,3 +1,5 @@
+import { GameEndX, GameOver, GameStateX } from "gbraver-burst-core";
+
 import { Animate } from "../../../../../../animation/animate";
 import { empty } from "../../../../../../animation/delay";
 import { GenesisBraverTD } from "../../../../view/td/armdozer-objects/genesis-braver";
@@ -5,14 +7,13 @@ import { LightningDozerTD } from "../../../../view/td/armdozer-objects/lightning
 import { NeoLandozerTD } from "../../../../view/td/armdozer-objects/neo-landozer";
 import { ShinBraverTD } from "../../../../view/td/armdozer-objects/shin-braver";
 import { WingDozerTD } from "../../../../view/td/armdozer-objects/wing-dozer";
+import { StateAnimationProps } from "../../state-animation-props";
 import { toGameOverParam } from "./game-over-param";
 import { genesisBraverWin } from "./genesis-braver";
 import { lightningDozerWin } from "./lightning-dozer";
 import { neoLandozerWin } from "./neo-landozer";
 import { shinBraverWin } from "./shin-braver";
 import { wingDozerWin } from "./wing-dozer";
-import { StateAnimationProps } from "../../state-animation-props";
-import { GameEndX, GameOver, GameStateX } from "gbraver-burst-core";
 
 /**
  * ゲームオーバアニメーション
@@ -29,26 +30,19 @@ export function gameOverAnimation(
     return empty();
   }
 
+  let animation = empty();
   const { winnerTdArmdozer } = param;
   if (winnerTdArmdozer instanceof ShinBraverTD) {
-    return shinBraverWin({ ...param, winnerTdArmdozer });
+    animation = shinBraverWin({ ...param, winnerTdArmdozer });
+  } else if (winnerTdArmdozer instanceof NeoLandozerTD) {
+    animation = neoLandozerWin({ ...param, winnerTdArmdozer });
+  } else if (winnerTdArmdozer instanceof LightningDozerTD) {
+    animation = lightningDozerWin({ ...param, winnerTdArmdozer });
+  } else if (winnerTdArmdozer instanceof WingDozerTD) {
+    animation = wingDozerWin({ ...param, winnerTdArmdozer });
+  } else if (winnerTdArmdozer instanceof GenesisBraverTD) {
+    animation = genesisBraverWin({ ...param, winnerTdArmdozer });
   }
 
-  if (winnerTdArmdozer instanceof NeoLandozerTD) {
-    return neoLandozerWin({ ...param, winnerTdArmdozer });
-  }
-
-  if (winnerTdArmdozer instanceof LightningDozerTD) {
-    return lightningDozerWin({ ...param, winnerTdArmdozer });
-  }
-
-  if (winnerTdArmdozer instanceof WingDozerTD) {
-    return wingDozerWin({ ...param, winnerTdArmdozer });
-  }
-
-  if (winnerTdArmdozer instanceof GenesisBraverTD) {
-    return genesisBraverWin({ ...param, winnerTdArmdozer });
-  }
-
-  return empty();
+  return animation;
 }

--- a/src/js/td-scenes/battle/animation/game-state/game-end/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/game-end/index.ts
@@ -1,11 +1,10 @@
-import type { GameEnd, GameStateX } from "gbraver-burst-core";
+import { GameEnd, GameStateX } from "gbraver-burst-core";
 
 import { Animate } from "../../../../../animation/animate";
 import { empty } from "../../../../../animation/delay";
-import type { StateAnimationProps } from "../state-animation-props";
+import { StateAnimationProps } from "../state-animation-props";
 import { evenMatchAnimation } from "./even-match/even-match";
 import { gameOverAnimation } from "./game-over/game-over";
-import { toGameOverParam } from "./game-over/game-over-param";
 
 /**
  * ゲーム終了アニメーション
@@ -18,18 +17,16 @@ export function gameEndAnimation(
   props: StateAnimationProps,
   gameState: GameStateX<GameEnd>,
 ): Animate {
-  if (gameState.effect.result.type === "EvenMatch") {
-    return evenMatchAnimation(props);
+  const { result } = gameState.effect;
+  switch (result.type) {
+    case "EvenMatch":
+      return evenMatchAnimation(props);
+    case "GameOver":
+      return gameOverAnimation(props, {
+        ...gameState,
+        effect: { ...gameState.effect, result },
+      });
+    default:
+      return empty();
   }
-
-  const gameOverParam =
-    gameState.effect.result.type === "GameOver"
-      ? toGameOverParam(props, gameState.effect.result)
-      : null;
-
-  if (gameOverParam) {
-    return gameOverAnimation(gameOverParam);
-  }
-
-  return empty();
 }


### PR DESCRIPTION
This pull request includes significant updates to the game-over animation logic in the `td-scenes/battle/animation/game-state/game-end` directory. The changes involve modifying function parameters, simplifying the code, and improving type usage.

### Refactoring and Simplification:

* [`src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over-param.ts`](diffhunk://#diff-afac5e81d7c7203bd5c0958aeb2f580f75032bef2504863a529e7aed6d709760L9-R35): Simplified the `toGameOverParam` function by removing unnecessary null checks and directly returning the result.

### Parameter and Import Updates:

* [`src/js/td-scenes/battle/animation/game-state/game-end/game-over/game-over.ts`](diffhunk://#diff-20ed4b18f4310e24d4f638f66494f17b278547219f03db28fdf0b696a246cb64R1-R11): Updated the `gameOverAnimation` function to take `StateAnimationProps` and `GameStateX<GameEndX<GameOver>>` as parameters, and refactored the function to use the new `toGameOverParam` function. [[1]](diffhunk://#diff-20ed4b18f4310e24d4f638f66494f17b278547219f03db28fdf0b696a246cb64R1-R11) [[2]](diffhunk://#diff-20ed4b18f4310e24d4f638f66494f17b278547219f03db28fdf0b696a246cb64L17-R47)
* [`src/js/td-scenes/battle/animation/game-state/game-end/index.ts`](diffhunk://#diff-6b1505fc5b04b04f7bad639cdf47dbf9635024eabebb9ea4c8f15a01dd481240L1-L8): Modified imports to include non-type imports from `gbraver-burst-core` and updated the `gameEndAnimation` function to use a switch statement for handling different game end results. [[1]](diffhunk://#diff-6b1505fc5b04b04f7bad639cdf47dbf9635024eabebb9ea4c8f15a01dd481240L1-L8) [[2]](diffhunk://#diff-6b1505fc5b04b04f7bad639cdf47dbf9635024eabebb9ea4c8f15a01dd481240L21-R32)