### PR TITLE
カウンター成立時のアニメーションをリファクタリングした

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/reflect/animation-param.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/animation-param.ts
@@ -7,26 +7,21 @@ import type { TDPlayer } from "../../../view/td/player";
 /** ダメージ反射アニメーション パラメータ */
 export type ReflectAnimationParam = {
   /** ダメージ反射効果 */
-  effect: Reflect;
-
+  readonly effect: Reflect;
   /** ダメージを受けた側 */
-  damaged: {
+  readonly damaged: {
     /** ダメージ反射後のステート */
-    state: PlayerState;
-
+    readonly state: PlayerState;
     /** スプライト */
-    sprite: ArmdozerSprite;
-
+    readonly sprite: ArmdozerSprite;
     /** 3Dプレイヤーオブジェクト */
-    td: TDPlayer;
-
+    readonly td: TDPlayer;
     /** HUDプレイヤーオブジェクト */
-    hud: HUDPlayer;
+    readonly hud: HUDPlayer;
   };
-
   /** ダメージ反射をした側 */
-  reflecting: {
+  readonly reflecting: {
     /** HUDプレイヤーオブジェクト */
-    hud: HUDPlayer;
+    readonly hud: HUDPlayer;
   };
 };

--- a/src/js/td-scenes/battle/animation/game-state/reflect/create-reflect-animation-param.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/create-reflect-animation-param.ts
@@ -1,0 +1,53 @@
+import { GameStateX, Reflect } from "gbraver-burst-core";
+
+import { StateAnimationProps } from "../state-animation-props";
+import { ReflectAnimationParam } from "./animation-param";
+
+/**
+ * ダメージ反射のアニメーションパラメータを生成する
+ * @param props ステートアニメーションプロパティ
+ * @param gameState ゲームステート
+ * @returns 生成結果、生成できない場合はnullを返す
+ */
+export function createReflectAnimationParam(
+  props: StateAnimationProps,
+  gameState: GameStateX<Reflect>,
+): ReflectAnimationParam | null {
+  const { view } = props;
+  const { effect, players } = gameState;
+  const stateOfDamaged = players.find(
+    (v) => v.playerId === effect.damagedPlayer,
+  );
+  const tdArmdozerOfDamaged = view.td.armdozers.find(
+    (v) => v.playerId === effect.damagedPlayer,
+  );
+  const tdPlayerOfDamaged = view.td.players.find(
+    (v) => v.playerId === effect.damagedPlayer,
+  );
+  const hudPlayerOfDamaged = view.hud.players.find(
+    (v) => v.playerId === effect.damagedPlayer,
+  );
+  const hudPlayerOfReflecting = view.hud.players.find(
+    (v) => v.playerId !== effect.damagedPlayer,
+  );
+  if (
+    !stateOfDamaged ||
+    !tdArmdozerOfDamaged ||
+    !tdPlayerOfDamaged ||
+    !hudPlayerOfDamaged ||
+    !hudPlayerOfReflecting
+  ) {
+    return null;
+  }
+
+  const damaged = {
+    state: stateOfDamaged,
+    sprite: tdArmdozerOfDamaged.sprite(),
+    td: tdPlayerOfDamaged,
+    hud: hudPlayerOfDamaged,
+  };
+  const reflecting = {
+    hud: hudPlayerOfReflecting,
+  };
+  return { effect, damaged, reflecting };
+}

--- a/src/js/td-scenes/battle/animation/game-state/reflect/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/index.ts
@@ -1,9 +1,9 @@
-import type { GameStateX, Reflect } from "gbraver-burst-core";
+import { GameStateX, Reflect } from "gbraver-burst-core";
 
 import { Animate } from "../../../../../animation/animate";
 import { empty } from "../../../../../animation/delay";
-import type { StateAnimationProps } from "../state-animation-props";
-import type { ReflectAnimationParam } from "./animation-param";
+import { StateAnimationProps } from "../state-animation-props";
+import { createReflectAnimationParam } from "./create-reflect-animation-param";
 import { deathLightning, lightning } from "./lightning";
 
 /**
@@ -17,55 +17,18 @@ export function reflectAnimation(
   props: StateAnimationProps,
   gameState: GameStateX<Reflect>,
 ): Animate {
-  const effect: Reflect = gameState.effect;
-  const stateOfDamaged = gameState.players.find(
-    (v) => v.playerId === effect.damagedPlayer,
-  );
-  const tdArmdozerOfDamaged = props.view.td.armdozers.find(
-    (v) => v.playerId === effect.damagedPlayer,
-  );
-  const tdPlayerOfDamaged = props.view.td.players.find(
-    (v) => v.playerId === effect.damagedPlayer,
-  );
-  const hudPlayerOfDamaged = props.view.hud.players.find(
-    (v) => v.playerId === effect.damagedPlayer,
-  );
-  const hudPlayerOfReflecting = props.view.hud.players.find(
-    (v) => v.playerId !== effect.damagedPlayer,
-  );
-
-  if (
-    !stateOfDamaged ||
-    !tdArmdozerOfDamaged ||
-    !tdPlayerOfDamaged ||
-    !hudPlayerOfDamaged ||
-    !hudPlayerOfReflecting
-  ) {
+  const animationParam = createReflectAnimationParam(props, gameState);
+  if (!animationParam) {
     return empty();
   }
 
-  const damaged = {
-    state: stateOfDamaged,
-    sprite: tdArmdozerOfDamaged.sprite(),
-    td: tdPlayerOfDamaged,
-    hud: hudPlayerOfDamaged,
-  };
-  const reflecting = {
-    hud: hudPlayerOfReflecting,
-  };
-  const animationParam: ReflectAnimationParam = {
-    effect,
-    damaged,
-    reflecting,
-  };
-
-  if (effect.effect === "Lightning" && effect.isDeath) {
-    return deathLightning(animationParam);
+  const { effect } = gameState;
+  switch (effect.effect) {
+    case "Lightning":
+      return effect.isDeath
+        ? deathLightning(animationParam)
+        : lightning(animationParam);
+    default:
+      return empty();
   }
-
-  if (effect.effect === "Lightning") {
-    return lightning(animationParam);
-  }
-
-  return empty();
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of reflect animations in the battle scene. The most important changes include making properties readonly, creating a new function to generate animation parameters, and refactoring the reflect animation function to use this new function.

### Improvements to reflect animation handling:

* [`src/js/td-scenes/battle/animation/game-state/reflect/animation-param.ts`](diffhunk://#diff-bfece99c3b6994f2e6102e959b33f7fb2371e729482cba806a42acfca565fd7fL10-R25): Modified the `ReflectAnimationParam` type to make all properties readonly.
* [`src/js/td-scenes/battle/animation/game-state/reflect/create-reflect-animation-param.ts`](diffhunk://#diff-ef6a34a589619760fee1b9ccbe67fea50ab75395d6306e89d0ac4e4a474e2a39R1-R53): Added a new function `createReflectAnimationParam` to generate parameters for reflect animations.
* [`src/js/td-scenes/battle/animation/game-state/reflect/index.ts`](diffhunk://#diff-567ba576174031d23dd6844d26bd9468ba49a97d15e92988d77e90c3a4fe8e7dL1-R6): Refactored the `reflectAnimation` function to use the `createReflectAnimationParam` function for generating animation parameters, simplifying the logic and improving readability. [[1]](diffhunk://#diff-567ba576174031d23dd6844d26bd9468ba49a97d15e92988d77e90c3a4fe8e7dL1-R6) [[2]](diffhunk://#diff-567ba576174031d23dd6844d26bd9468ba49a97d15e92988d77e90c3a4fe8e7dL20-R34)