### PR TITLE
Animateの再生オプションをオブジェクト化した

### DIFF
--- a/src/js/animation/animate.ts
+++ b/src/js/animation/animate.ts
@@ -3,6 +3,12 @@ import { Group } from "@tweenjs/tween.js";
 import { GBTween } from "./gb-tween";
 import { GlobalTweenGroup } from "./global-tween-group";
 
+/** アニメーション再生オプション */
+export type AnimationPlayOptions = {
+  /** Tweenグループ */
+  group?: Group;
+};
+
 /**
  * アニメーション
  * tween.jsではアニメーションのモジュール化の機能が十分でないので、それを補うべく本クラスを作成した
@@ -86,10 +92,11 @@ export class Animate {
 
   /**
    * アニメーションを再生する
-   * @param group アニメーショングループ
+   * @param options 再生オプション
    * @returns アニメーション再生完了後に呼び出されるPromise
    */
-  play(group?: Group): Promise<void> {
+  play(options?: AnimationPlayOptions): Promise<void> {
+    const group = options?.group;
     const targetGroup = group ?? GlobalTweenGroup;
     this._tweens.forEach((tween) => {
       targetGroup.add(tween);

--- a/src/js/game-object/battery-selector/procedure/battery-change.ts
+++ b/src/js/game-object/battery-selector/procedure/battery-change.ts
@@ -23,5 +23,5 @@ export function batteryChange(
       model.battery = battery;
     }),
     changeNeedle(props, needle),
-  ).play({group: batteryChangeTween});
+  ).play({ group: batteryChangeTween });
 }

--- a/src/js/game-object/battery-selector/procedure/battery-change.ts
+++ b/src/js/game-object/battery-selector/procedure/battery-change.ts
@@ -23,5 +23,5 @@ export function batteryChange(
       model.battery = battery;
     }),
     changeNeedle(props, needle),
-  ).play(batteryChangeTween);
+  ).play({group: batteryChangeTween});
 }

--- a/src/js/game-object/battery-selector/procedure/play-battery-minus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-battery-minus-pop.ts
@@ -10,5 +10,5 @@ export async function playBatteryMinusPop(props: BatterySelectorProps) {
   const { batteryMinusTween } = props;
   batteryMinusTween.update();
   batteryMinusTween.removeAll();
-  await batteryMinusPop(props).play({group: batteryMinusTween});
+  await batteryMinusPop(props).play({ group: batteryMinusTween });
 }

--- a/src/js/game-object/battery-selector/procedure/play-battery-minus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-battery-minus-pop.ts
@@ -10,5 +10,5 @@ export async function playBatteryMinusPop(props: BatterySelectorProps) {
   const { batteryMinusTween } = props;
   batteryMinusTween.update();
   batteryMinusTween.removeAll();
-  await batteryMinusPop(props).play(batteryMinusTween);
+  await batteryMinusPop(props).play({group: batteryMinusTween});
 }

--- a/src/js/game-object/battery-selector/procedure/play-battery-plus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-battery-plus-pop.ts
@@ -10,5 +10,5 @@ export async function playBatteryPlusPop(props: BatterySelectorProps) {
   const { batteryPlusTween } = props;
   batteryPlusTween.update();
   batteryPlusTween.removeAll();
-  await batteryPlusPop(props).play({ group: batteryPlusTween});
+  await batteryPlusPop(props).play({ group: batteryPlusTween });
 }

--- a/src/js/game-object/battery-selector/procedure/play-battery-plus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-battery-plus-pop.ts
@@ -10,5 +10,5 @@ export async function playBatteryPlusPop(props: BatterySelectorProps) {
   const { batteryPlusTween } = props;
   batteryPlusTween.update();
   batteryPlusTween.removeAll();
-  await batteryPlusPop(props).play(batteryPlusTween);
+  await batteryPlusPop(props).play({ group: batteryPlusTween});
 }

--- a/src/js/game-object/battery-selector/procedure/play-silently-battery-minus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-silently-battery-minus-pop.ts
@@ -10,5 +10,5 @@ export async function playSilentlyBatteryMinusPop(props: BatterySelectorProps) {
   const { batteryMinusTween } = props;
   batteryMinusTween.update();
   batteryMinusTween.removeAll();
-  await silentlyBatteryMinusPop(props).play({group: batteryMinusTween});
+  await silentlyBatteryMinusPop(props).play({ group: batteryMinusTween });
 }

--- a/src/js/game-object/battery-selector/procedure/play-silently-battery-minus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-silently-battery-minus-pop.ts
@@ -10,5 +10,5 @@ export async function playSilentlyBatteryMinusPop(props: BatterySelectorProps) {
   const { batteryMinusTween } = props;
   batteryMinusTween.update();
   batteryMinusTween.removeAll();
-  await silentlyBatteryMinusPop(props).play(batteryMinusTween);
+  await silentlyBatteryMinusPop(props).play({group: batteryMinusTween});
 }

--- a/src/js/game-object/battery-selector/procedure/play-silently-battery-plus-pop.ts
+++ b/src/js/game-object/battery-selector/procedure/play-silently-battery-plus-pop.ts
@@ -10,5 +10,5 @@ export async function playSilentlyBatteryPlusPop(props: BatterySelectorProps) {
   const { batteryPlusTween } = props;
   batteryPlusTween.update();
   batteryPlusTween.removeAll();
-  await silentlyBatteryPlusPop(props).play(batteryPlusTween);
+  await silentlyBatteryPlusPop(props).play({ group: batteryPlusTween });
 }

--- a/src/js/game-object/time-scale-button/procedure/on-button-push.ts
+++ b/src/js/game-object/time-scale-button/procedure/on-button-push.ts
@@ -15,6 +15,6 @@ export function onButtonPush(props: TimeScaleButtonProps) {
   toggleTween.update();
   toggleTween.removeAll();
   const nextTimeScale = getNextTimeScale(model.timeScale);
-  toggle(props, nextTimeScale).play(toggleTween);
+  toggle(props, nextTimeScale).play({ group: toggleTween });
   toggleNotify.next(nextTimeScale);
 }

--- a/src/js/td-scenes/battle/animate-player.ts
+++ b/src/js/td-scenes/battle/animate-player.ts
@@ -1,4 +1,4 @@
-import { Animate, AnimationPlayOptions } from "../../animation/animate";
+import { Animate } from "../../animation/animate";
 
 /** AnimatePlayerのプロパティ */
 interface AnimatePlayerProps {
@@ -7,7 +7,7 @@ interface AnimatePlayerProps {
 }
 
 /**
- * Animateを再生するプレイヤー
+ * 戦闘画面でのAnimateプレイヤー
  * タイムスケールなどシーン全体での設定を保持、適用するために利用される
  */
 export interface AnimatePlayer extends AnimatePlayerProps {
@@ -17,7 +17,7 @@ export interface AnimatePlayer extends AnimatePlayerProps {
    * @param options 再生オプション
    * @returns アニメーションが完了したら発火するPromise
    */
-  play(animate: Animate, options?: AnimationPlayOptions): Promise<void>;
+  play(animate: Animate): Promise<void>;
 }
 
 /** AnimatePlayerのシンプルな実装 */
@@ -34,8 +34,8 @@ class SimpleAnimatePlayer implements AnimatePlayer {
   }
 
   /** @override */
-  play(animate: Animate, options?: AnimationPlayOptions) {
-    return animate.timeScale(this.timeScale).play(options);
+  play(animate: Animate) {
+    return animate.timeScale(this.timeScale).play();
   }
 }
 

--- a/src/js/td-scenes/battle/animate-player.ts
+++ b/src/js/td-scenes/battle/animate-player.ts
@@ -37,7 +37,7 @@ class SimpleAnimatePlayer implements AnimatePlayer {
 
   /** @override */
   play(animate: Animate, group?: Group) {
-    return animate.timeScale(this.timeScale).play(group);
+    return animate.timeScale(this.timeScale).play({ group });
   }
 }
 

--- a/src/js/td-scenes/battle/animate-player.ts
+++ b/src/js/td-scenes/battle/animate-player.ts
@@ -14,7 +14,6 @@ export interface AnimatePlayer extends AnimatePlayerProps {
   /**
    * アニメーションを再生する
    * @param animate アニメーション
-   * @param options 再生オプション
    * @returns アニメーションが完了したら発火するPromise
    */
   play(animate: Animate): Promise<void>;

--- a/src/js/td-scenes/battle/animate-player.ts
+++ b/src/js/td-scenes/battle/animate-player.ts
@@ -1,6 +1,4 @@
-import { Group } from "@tweenjs/tween.js";
-
-import { Animate } from "../../animation/animate";
+import { Animate, AnimationPlayOptions } from "../../animation/animate";
 
 /** AnimatePlayerのプロパティ */
 interface AnimatePlayerProps {
@@ -16,10 +14,10 @@ export interface AnimatePlayer extends AnimatePlayerProps {
   /**
    * アニメーションを再生する
    * @param animate アニメーション
-   * @param group アニメーショングループ
+   * @param options 再生オプション
    * @returns アニメーションが完了したら発火するPromise
    */
-  play(animate: Animate, group?: Group): Promise<void>;
+  play(animate: Animate, options?: AnimationPlayOptions): Promise<void>;
 }
 
 /** AnimatePlayerのシンプルな実装 */
@@ -36,8 +34,8 @@ class SimpleAnimatePlayer implements AnimatePlayer {
   }
 
   /** @override */
-  play(animate: Animate, group?: Group) {
-    return animate.timeScale(this.timeScale).play({ group });
+  play(animate: Animate, options?: AnimationPlayOptions) {
+    return animate.timeScale(this.timeScale).play(options);
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `AnimationPlayOptions` type to simplify the handling of animation play options across various functions. The key changes include updating function signatures to use the new type and modifying the relevant function calls to pass the options accordingly.

### Introduction of `AnimationPlayOptions` type:

* [`src/js/animation/animate.ts`](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6R6-R11): Added `AnimationPlayOptions` type to encapsulate animation play options, including an optional `group` property. Updated the `play` method of the `Animate` class to accept `AnimationPlayOptions` instead of a `Group` parameter. [[1]](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6R6-R11) [[2]](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6L89-R99)

### Updates to function signatures and calls:

* [`src/js/game-object/battery-selector/procedure/battery-change.ts`](diffhunk://#diff-efcdc90bd5ec0385e4eeffaf6378886ab5c6d135d9d5aa4d6d68c000ab4ad922L26-R26): Modified the `play` call to use the new `AnimationPlayOptions` type.
* [`src/js/game-object/battery-selector/procedure/play-battery-minus-pop.ts`](diffhunk://#diff-4ac1b400b78c0e46f3aa8fd6138976f01e3ffac64def11dd4baa86720aab66fbL13-R13): Updated the `play` call to pass the `group` property within the `AnimationPlayOptions` object.
* [`src/js/game-object/battery-selector/procedure/play-battery-plus-pop.ts`](diffhunk://#diff-81f0733b0fcff3218c4b39b6b981b44f5b0fcd4e43527058576669b05c6eeb2cL13-R13): Adjusted the `play` call to use the new `AnimationPlayOptions` type.
* [`src/js/game-object/battery-selector/procedure/play-silently-battery-minus-pop.ts`](diffhunk://#diff-dd272da6d5192b401b4905ac9bba12492915f5840643a1b4baf76a8d8c782847L13-R13): Changed the `play` call to pass the `group` property within the `AnimationPlayOptions` object.
* [`src/js/game-object/battery-selector/procedure/play-silently-battery-plus-pop.ts`](diffhunk://#diff-8a687a84ee33c11e313c33f602f9b70882b9df2db2f7e580e35247b085d21f93L13-R13): Updated the `play` call to use the new `AnimationPlayOptions` type.
* [`src/js/game-object/time-scale-button/procedure/on-button-push.ts`](diffhunk://#diff-ced1850da122b235408df9632df0ac43b1bc6085d20947600f57cdce58507282L18-R18): Modified the `play` call to pass the `group` property within the `AnimationPlayOptions` object.

### Code cleanup:

* [`src/js/td-scenes/battle/animate-player.ts`](diffhunk://#diff-aacf726995a5cf7a38c3c0cecd95e3c2a57fe4d6bcc1dccd71a647baf2bb2ee7L1-L2): Removed the unused import of `Group` from `@tweenjs/tween.js`. Updated the `AnimatePlayer` interface and `SimpleAnimatePlayer` class to use the new `AnimationPlayOptions` type for the `play` method. [[1]](diffhunk://#diff-aacf726995a5cf7a38c3c0cecd95e3c2a57fe4d6bcc1dccd71a647baf2bb2ee7L1-L2) [[2]](diffhunk://#diff-aacf726995a5cf7a38c3c0cecd95e3c2a57fe4d6bcc1dccd71a647baf2bb2ee7L12-R20) [[3]](diffhunk://#diff-aacf726995a5cf7a38c3c0cecd95e3c2a57fe4d6bcc1dccd71a647baf2bb2ee7L39-R38)