### PR TITLE
ハンバーガーメニュー外にイベントが伝搬しようようにした

### DIFF
--- a/src/js/game-dom/battle-hamburger-menu/procedure/bind-event-listeners.ts
+++ b/src/js/game-dom/battle-hamburger-menu/procedure/bind-event-listeners.ts
@@ -21,6 +21,7 @@ import { onRetryButtonPush } from "./on-retry-button-push";
 import { onRetryCancelButtonPush } from "./on-retry-cancel-button-push";
 import { onRetryConfirmDialogCloserPush } from "./on-retry-confirm-dialog-closer-push";
 import { onRetryPush } from "./on-retry-push";
+import { onRootPush } from "./on-root-push";
 
 /**
  * イベントリスナーをバインドする
@@ -31,6 +32,9 @@ export function bindEventListeners(
   props: BattleHamburgerMenuProps,
 ): Unsubscribable[] {
   return [
+    domPushStream(props.root).subscribe((action) => {
+      onRootPush(props, action);
+    }),
     domPushStream(props.hamburgerIcon).subscribe((action) => {
       onHamburgerIconPush(props, action);
     }),

--- a/src/js/game-dom/battle-hamburger-menu/procedure/on-root-push.ts
+++ b/src/js/game-dom/battle-hamburger-menu/procedure/on-root-push.ts
@@ -1,0 +1,12 @@
+import { PushDOM } from "../../../dom/push-dom";
+import { BattleHamburgerMenuProps } from "../props";
+
+/**
+ * ルート押下時の処理
+ * @param props プロパティ
+ * @param action アクション
+ */
+export function onRootPush(props: BattleHamburgerMenuProps, action: PushDOM) {
+  action.event.preventDefault();
+  action.event.stopPropagation();
+}


### PR DESCRIPTION
This pull request introduces a new event listener for handling root button pushes in the battle hamburger menu. The most important changes include adding a new import statement, modifying the `bindEventListeners` function to include the new listener, and implementing the `onRootPush` function.

### Event Listener Addition:

* [`src/js/game-dom/battle-hamburger-menu/procedure/bind-event-listeners.ts`](diffhunk://#diff-f02536ecda39735d72254f8d72dad3438b248991b8206c7d58d118e0171db3feR24): Added import for `onRootPush` and included a new subscription for the root button push event in the `bindEventListeners` function. [[1]](diffhunk://#diff-f02536ecda39735d72254f8d72dad3438b248991b8206c7d58d118e0171db3feR24) [[2]](diffhunk://#diff-f02536ecda39735d72254f8d72dad3438b248991b8206c7d58d118e0171db3feR35-R37)

### New Function Implementation:

* [`src/js/game-dom/battle-hamburger-menu/procedure/on-root-push.ts`](diffhunk://#diff-aa09316298421c74325cfee6352f20dcf27f73c1976bfb4f21d045bcfdff9e6eR1-R12): Implemented the `onRootPush` function to handle the root button push event by preventing the default action and stopping propagation.