### PR TITLE
Animateプロパティを外部からReadonlyにした

### DIFF
--- a/src/js/animation/align-end.ts
+++ b/src/js/animation/align-end.ts
@@ -10,11 +10,11 @@ import { delay } from "./delay";
 export function alignEnd(...animations: Animate[]): Animate {
   const maxDuration = Math.max(
     0,
-    ...animations.map((animate) => animate._time),
+    ...animations.map((animate) => animate.time),
   );
   return all(
     ...animations.map((animate) =>
-      delay(maxDuration - animate._time).chain(animate),
+      delay(maxDuration - animate.time).chain(animate),
     ),
   );
 }

--- a/src/js/animation/align-end.ts
+++ b/src/js/animation/align-end.ts
@@ -8,10 +8,7 @@ import { delay } from "./delay";
  * @returns アニメーション
  */
 export function alignEnd(...animations: Animate[]): Animate {
-  const maxDuration = Math.max(
-    0,
-    ...animations.map((animate) => animate.time),
-  );
+  const maxDuration = Math.max(0, ...animations.map((animate) => animate.time));
   return all(
     ...animations.map((animate) =>
       delay(maxDuration - animate.time).chain(animate),

--- a/src/js/animation/all.ts
+++ b/src/js/animation/all.ts
@@ -9,7 +9,7 @@ import { empty } from "./delay";
  */
 export function all(...animations: Animate[]): Animate {
   const next = animations.reduce(
-    (a, b) => (a._time < b._time ? b : a),
+    (a, b) => (a.time < b.time ? b : a),
     empty(),
   );
   const parallels = animations.filter((v) => v !== next);

--- a/src/js/animation/all.ts
+++ b/src/js/animation/all.ts
@@ -8,10 +8,7 @@ import { empty } from "./delay";
  * @returns アニメーション
  */
 export function all(...animations: Animate[]): Animate {
-  const next = animations.reduce(
-    (a, b) => (a.time < b.time ? b : a),
-    empty(),
-  );
+  const next = animations.reduce((a, b) => (a.time < b.time ? b : a), empty());
   const parallels = animations.filter((v) => v !== next);
   return empty().chain(next, ...parallels);
 }

--- a/src/js/animation/animate.ts
+++ b/src/js/animation/animate.ts
@@ -67,7 +67,7 @@ export class Animate {
   private _tweens: GBTween<any>[];
   /* eslint-enable */
   /** 全体の再生時間 */
-  _time: number;
+  private _time: number;
 
   /**
    * 連続したTweenの最初、最後からTweenAnimatonを生成する
@@ -99,6 +99,14 @@ export class Animate {
   get end(): GBTween<any> {
     /* eslint-enable */
     return this._end;
+  }
+
+  /**
+   * 全体の再生時間のgetter
+   * @returns 全体の再生時間
+   */
+  get time(): number {
+    return this._time;
   }
 
   /**

--- a/src/js/animation/animate.ts
+++ b/src/js/animation/animate.ts
@@ -62,7 +62,7 @@ export class Animate {
   /** 開始Tween */
   private _start: GBTween<any>;
   /** 終了Tween */
-  _end: GBTween<any>;
+  private _end: GBTween<any>;
   /** このアニメーションが保持するすべてのTween（_start、_endを含む）*/
   private _tweens: GBTween<any>[];
   /* eslint-enable */
@@ -89,6 +89,16 @@ export class Animate {
     this._end = end;
     this._tweens = tweens;
     this._time = time;
+  }
+
+  /**
+   * 終了Tweenのgetter
+   * @returns 終了Tween
+   */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  get end(): GBTween<any> {
+    /* eslint-enable */
+    return this._end;
   }
 
   /**

--- a/src/js/animation/animate.ts
+++ b/src/js/animation/animate.ts
@@ -60,11 +60,11 @@ export type AnimationPlayOptions = Partial<SignalContainer> & {
 export class Animate {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   /** 開始Tween */
-  _start: GBTween<any>;
+  private _start: GBTween<any>;
   /** 終了Tween */
   _end: GBTween<any>;
   /** このアニメーションが保持するすべてのTween（_start、_endを含む）*/
-  _tweens: GBTween<any>[];
+  private _tweens: GBTween<any>[];
   /* eslint-enable */
   /** 全体の再生時間 */
   _time: number;

--- a/test/js/animation/align-end.test.ts
+++ b/test/js/animation/align-end.test.ts
@@ -6,5 +6,5 @@ test("alignEndだと、一番長いアニメーション時間で再生される
   const animation2 = delay(2000);
   const animation3 = delay(4000);
   const result = alignEnd(animation1, animation2, animation3);
-  expect(result._time).toBe(4000);
+  expect(result.time).toBe(4000);
 });

--- a/test/js/animation/all.test.ts
+++ b/test/js/animation/all.test.ts
@@ -7,5 +7,5 @@ test("再生時間が一番長いものがnextに設定されている", () => {
   const p3 = tween({}, (t) => t.to({}, 1000));
   const v = all(p1, p2, p3);
   expect(v.end).toBe(p3.end);
-  expect(v._time).toBe(1000);
+  expect(v.time).toBe(1000);
 });

--- a/test/js/animation/all.test.ts
+++ b/test/js/animation/all.test.ts
@@ -6,6 +6,6 @@ test("再生時間が一番長いものがnextに設定されている", () => {
   const p2 = tween({}, (t) => t.to({}, 300));
   const p3 = tween({}, (t) => t.to({}, 1000));
   const v = all(p1, p2, p3);
-  expect(v._end).toBe(p3._end);
+  expect(v.end).toBe(p3.end);
   expect(v._time).toBe(1000);
 });

--- a/test/js/animation/delay.test.ts
+++ b/test/js/animation/delay.test.ts
@@ -2,5 +2,5 @@ import { delay } from "../../../src/js/animation/delay";
 
 test("待ち時間が再生時間としてセットされている", () => {
   const v = delay(400);
-  expect(v._time).toBe(400);
+  expect(v.time).toBe(400);
 });

--- a/test/js/animation/on-start.test.ts
+++ b/test/js/animation/on-start.test.ts
@@ -4,5 +4,5 @@ test("onStartの再生時間は0である", () => {
   const v = onStart(() => {
     // NOP
   });
-  expect(v._time).toBe(0);
+  expect(v.time).toBe(0);
 });

--- a/test/js/animation/tween.test.ts
+++ b/test/js/animation/tween.test.ts
@@ -2,12 +2,12 @@ import { tween } from "../../../src/js/animation/tween";
 
 test("シンプルなTweenの再生時間が正しくセットされている", () => {
   const v = tween({}, (t) => t.to({}, 500));
-  expect(v._time).toBe(500);
+  expect(v.time).toBe(500);
 });
 
 test("チェインした場合でも、正しい再生時間がセットされている", () => {
   const v = tween({}, (t) => t.to({}, 500)).chain(
     tween({}, (t) => t.to({}, 500)),
   );
-  expect(v._time).toBe(1000);
+  expect(v.time).toBe(1000);
 });


### PR DESCRIPTION
This pull request includes several changes to improve the encapsulation of the `Animate` class and update references to its internal properties. The main changes involve making certain properties private and adding getter methods for them, as well as updating related code and tests to use these new getters.

Encapsulation improvements:

* [`src/js/animation/animate.ts`](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6L63-R70): Made `_start`, `_end`, `_tweens`, and `_time` properties private and added getter methods for `_end` and `_time`. [[1]](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6L63-R70) [[2]](diffhunk://#diff-8cb6420e00028e2de4a7c0ac863f3f3cd676bae6d4064f6824ed9cfd8352a6c6R94-R111)

Code updates to use new getters:

* [`src/js/animation/align-end.ts`](diffhunk://#diff-28614c94aadf8e85facb67f10c287d0aa00797f03eeecbbac4811b92dd8bcb1eL13-R17): Updated references to `animate._time` to use the new `time` getter.
* [`src/js/animation/all.ts`](diffhunk://#diff-c8c82ebd22a657b77aaf92b2760d5caaed2be41009c07bdbbc7d369b1a308056L12-R12): Updated references to `a._time` and `b._time` to use the new `time` getter.

Test updates to use new getters:

* [`test/js/animation/align-end.test.ts`](diffhunk://#diff-fac521d03f8f6950f7bf97da2fa539539edd7363b029d2ca3fef765c95fdde47L9-R9): Updated reference to `result._time` to use the new `time` getter.
* [`test/js/animation/all.test.ts`](diffhunk://#diff-2c09243f70c5ad0f2ffd1ba42115db6dd7d92932d68f2db2500df0bbefcb3267L9-R10): Updated references to `v._end` and `v._time` to use the new `end` and `time` getters.
* [`test/js/animation/delay.test.ts`](diffhunk://#diff-3274d175e1035164d217bd1b76c870424554763fb7d1d7bd04f0841c1d125a0cL5-R5): Updated reference to `v._time` to use the new `time` getter.
* [`test/js/animation/on-start.test.ts`](diffhunk://#diff-e2108f57af90990928f06f40989f3af28a5300b39a8a7133ae45eaedd7f4c2aaL7-R7): Updated reference to `v._time` to use the new `time` getter.
* [`test/js/animation/tween.test.ts`](diffhunk://#diff-681687cf8522400a10bcddde9aa3d88d5acdcbcdb8f31f24155755b8d634efd6L5-R12): Updated references to `v._time` to use the new `time` getter.