### PR TITLE
バトル強制終了時にポストバトルボタンを消すようにした

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
@@ -20,6 +20,8 @@ import { switchWaitingDialog } from "../switch-dialog/switch-waiting-dialog";
 async function forceEndStoryBattle(
   props: Readonly<GameProps & { inProgress: Story }>,
 ) {
+  props.domFloaters.hiddenPostBattle();
+
   const selectedEpisodeId =
     props.inProgress.story.type === "PlayingEpisode"
       ? props.inProgress.story.episode.id
@@ -50,11 +52,12 @@ async function forceEndNetBattle(
     }
   >,
 ) {
+  props.domFloaters.hiddenPostBattle();
+
   const dialog = new WaitingDialog("通信中......");
   switchWaitingDialog(props, dialog);
   await props.api.disconnectWebsocket();
   props.domDialogBinder.hidden();
-
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();
@@ -74,6 +77,7 @@ async function forceEndNetBattle(
  * @param props ゲームプロパティ
  */
 async function forceEndBattle(props: Readonly<GameProps>) {
+  props.domFloaters.hiddenPostBattle();
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();


### PR DESCRIPTION
This pull request includes changes to the `src/js/game/game-procedure/on-game-action/on-force-end-battle.ts` file to ensure that the `hiddenPostBattle` method is called in various battle-ending functions. The most important changes include adding calls to `props.domFloaters.hiddenPostBattle()` in the `forceEndStoryBattle`, `forceEndNetBattle`, and `forceEndBattle` functions.

Changes to ensure `hiddenPostBattle` is called:

* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R23-R24): Added `props.domFloaters.hiddenPostBattle()` to the `forceEndStoryBattle` function to hide post-battle floaters.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R55-L57): Added `props.domFloaters.hiddenPostBattle()` to the `forceEndNetBattle` function to hide post-battle floaters.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R80): Added `props.domFloaters.hiddenPostBattle()` to the `forceEndBattle` function to hide post-battle floaters.