### PR TITLE
強制リトライをリファクタリングした

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
@@ -75,6 +75,7 @@ async function forceEndNetBattle(
 /**
  * 汎用的なバトル強制終了
  * @param props ゲームプロパティ
+ * @returns 処理が完了したら発火するPromise
  */
 async function forceEndBattle(props: Readonly<GameProps>) {
   props.domFloaters.hiddenPostBattle();
@@ -104,6 +105,7 @@ type ForceEndBattleOptions = {
  * プレイヤーによるバトル強制終了
  * 本関数にはinProgressを更新する副作用がある
  * @param options オプション
+ * @returns 処理が完了したら発火するPromise
  */
 export async function onForceEndBattle(options: ForceEndBattleOptions) {
   const { props } = options;

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
@@ -15,7 +15,7 @@ import { switchWaitingDialog } from "../switch-dialog/switch-waiting-dialog";
 /**
  * ストーリーモードバトルを強制終了する
  * @param props ゲームプロパティ
- * @returns バトルを強制終了した場合はtrue, それ以外はfalse
+ * @returns 処理が完了したら発火するPromise
  */
 async function forceEndStoryBattle(
   props: Readonly<GameProps & { inProgress: Story }>,
@@ -43,7 +43,7 @@ async function forceEndStoryBattle(
 /**
  * ネットバトルを強制終了する
  * @param props ゲームプロパティ
- * @returns バトルを強制終了した場合はtrue, それ以外はfalse
+ * @returns 処理が完了したら発火するPromise
  */
 async function forceEndNetBattle(
   props: Readonly<

--- a/src/js/game/game-procedure/on-game-action/on-force-retry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-retry.ts
@@ -38,13 +38,13 @@ async function forceRetryNPCBattle(
 async function forceRetryStoryBattle(
   props: Readonly<GameProps & { inProgress: Story }>,
 ) {
-  const { inProgress } = props;
+  const { story } = props.inProgress;
   const episode = (() => {
-    switch (inProgress.story.type) {
+    switch (story.type) {
       case "PlayingEpisode":
-        return inProgress.story.episode;
+        return story.episode;
       case "GoingNextEpisode":
-        return inProgress.story.currentEpisode;
+        return story.currentEpisode;
       default:
         return batterySystemTutorial;
     }

--- a/src/js/game/game-procedure/on-game-action/on-force-retry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-retry.ts
@@ -58,7 +58,7 @@ type OnForceRetryOptions = {
   /** ゲームプロパティ */
   readonly props: Readonly<GameProps>;
   /** アクション */
-  readonly action: ForceRetry;
+  readonly action: Readonly<ForceRetry>;
 };
 
 /**


### PR DESCRIPTION
This pull request includes changes to the `on-game-action` and `on-force-retry` modules to update the return types of several functions and refactor the retry logic. The most important changes include updating the return types to promises, refactoring retry functions, and enhancing type safety.

Return type updates:

* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674L18-R18): Updated the return type of `forceEndStoryBattle`, `forceEndNetBattle`, `forceEndBattle`, and `onForceEndBattle` functions to promises. [[1]](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674L18-R18) [[2]](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674L46-R46) [[3]](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R78) [[4]](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R108)

Refactoring retry functions:

* [`src/js/game/game-procedure/on-game-action/on-force-retry.ts`](diffhunk://#diff-1ca7489ae1c9ee02cb3736e3c1f36d227689ea7036d58d33c0c8bbe6cb0c0682R1-R78): Refactored `forceRetryNPCBattleIfNeeded` to `forceRetryNPCBattle` and `forceRetryStory` to `forceRetryStoryBattle`, and updated their logic to improve clarity and maintainability.

Type safety enhancements:

* [`src/js/game/game-procedure/on-game-action/on-force-retry.ts`](diffhunk://#diff-1ca7489ae1c9ee02cb3736e3c1f36d227689ea7036d58d33c0c8bbe6cb0c0682R1-R78): Improved type safety by updating the `OnForceRetryOptions` type to use `readonly` properties.