### PR TITLE
ミニコントローラーのスタイルを変更

### DIFF
--- a/src/css/mini-controller.css
+++ b/src/css/mini-controller.css
@@ -4,24 +4,24 @@
 @media (orientation: landscape) {
   .mini-controller {
     --font-size: calc(var(--responsive-font-size) * 1);
-    --gap: 1px;
+    --gap: 2px;
+    --button-background-color: #4d4d4d;
     --button-padding: calc(var(--responsive-font-size) * 0.5);
     --button-font-color: var(--font-color);
-    --enabled-button-color: var(--sub-button-background-color);
-    --disabled-button-color: #a9a9a9;
+    --button-border-radius: calc(var(--dialog-border-radius) * 0.5);
 
     min-width: calc(var(--responsive-font-size) * 15);
     position: fixed;
     bottom: max(calc(var(--responsive-font-size) * 1), var(--safe-area-bottom));
     right: max(calc(var(--responsive-font-size) * 1), var(--safe-area-right));
-    background-color: var(--font-color);
+    background-color: #000;
     border-radius: var(--dialog-border-radius);
     z-index: var(--zindex-mini-controller);
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr 1fr;
     gap: var(--gap);
-    padding: var(--gap);
+    padding: 6px;
     box-shadow: var(--sub-button-box-shadow);
   }
 }
@@ -57,19 +57,19 @@
 }
 
 .mini-controller__battery--enabled {
-  background-color: var(--enabled-button-color);
+  background-color: var(--button-background-color);
 }
 
 .mini-controller__battery--disabled {
-  background-color: var(--disabled-button-color);
+  background-color: var(--button-background-color);
 }
 
 .mini-controller__battery--first {
-  border-top-left-radius: var(--dialog-border-radius);
+  border-top-left-radius: var(--button-border-radius);
 }
 
 .mini-controller__battery--last {
-  border-top-right-radius: var(--dialog-border-radius);
+  border-top-right-radius: var(--button-border-radius);
 }
 
 .mini-controller__battery--invisible {
@@ -81,7 +81,7 @@
   grid-row: 2;
   color: var(--button-font-color);
   font-size: var(--font-size);
-  border-bottom-right-radius: var(--dialog-border-radius);
+  border-bottom-right-radius: var(--button-border-radius);
   padding: var(--button-padding);
   border: none;
   outline: none;
@@ -92,11 +92,11 @@
 }
 
 .mini-controller__burst--enabled {
-  background-color: var(--enabled-button-color);
+  background-color: var(--button-background-color);
 }
 
 .mini-controller__burst--disabled {
-  background-color: var(--disabled-button-color);
+  background-color: var(--button-background-color);
 }
 
 .mini-controller__pilot {
@@ -104,7 +104,7 @@
   grid-row: 2;
   color: var(--button-font-color);
   font-size: var(--font-size);
-  border-bottom-left-radius: var(--dialog-border-radius);
+  border-bottom-left-radius: var(--button-border-radius);
   padding: var(--button-padding);
   border: none;
   outline: none;
@@ -115,9 +115,9 @@
 }
 
 .mini-controller__pilot--enabled {
-  background-color: var(--enabled-button-color);
+  background-color: var(--button-background-color);
 }
 
 .mini-controller__pilot--disabled {
-  background-color: var(--disabled-button-color);
+  background-color: var(--button-background-color);
 }

--- a/src/css/mini-controller.css
+++ b/src/css/mini-controller.css
@@ -16,6 +16,7 @@
     right: max(calc(var(--responsive-font-size) * 1), var(--safe-area-right));
     background-color: #000;
     border-radius: var(--dialog-border-radius);
+    border: var(--dialog-border);
     z-index: var(--zindex-mini-controller);
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
This pull request includes updates to the `src/css/mini-controller.css` file to improve the visual consistency and appearance of the mini-controller component. The most important changes involve adjusting the gap size, button background color, border radius, and padding.

Visual consistency improvements:

* Changed the `--gap` variable from `1px` to `2px` to increase spacing between elements.
* Updated the `--button-background-color` to `#4d4d4d` for a consistent button appearance.
* Adjusted the `--button-border-radius` to `calc(var(--dialog-border-radius) * 0.5)` for a more cohesive look.
* Set the `background-color` of the mini-controller to `#000` for a uniform background.
* Modified the padding to `6px` for better spacing around the mini-controller.

Button state styling updates:

* Changed the background color of enabled and disabled buttons to use `--button-background-color` for consistency. [[1]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL60-R73) [[2]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL95-R108) [[3]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL118-R123)
* Updated the border radius for various button states to use `--button-border-radius` for uniformity. [[1]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL60-R73) [[2]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL84-R85) [[3]](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL95-R108)