### PR TITLE
NPCバトルステートの更新をリファクタリングした

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-end-battle/execute-post-npc-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-end-battle/execute-post-npc-battle.ts
@@ -8,7 +8,10 @@ import { EndBattle } from "../../../game-actions/end-battle";
 import { GameProps } from "../../../game-props";
 import { InProgress } from "../../../in-progress";
 import { NPCBattle } from "../../../in-progress/npc-battle";
-import { NPCBattleResult } from "../../../npc-battle/npc-battle-result";
+import {
+  getNPCBattleResult,
+  NPCBattleResult,
+} from "../../../npc-battle/npc-battle-result";
 import { updateNPCBattleState } from "../../../npc-battle/updated-npc-battle-state";
 
 /**
@@ -46,18 +49,13 @@ export async function executePostNPCBattle(
     return inProgress;
   }
 
-  const updated = updateNPCBattleState(
-    inProgress.npcBattle.state,
-    gameEnd.result,
-  );
-  if (!updated) {
-    return inProgress;
-  }
-
-  const buttons = postNPCBattleButtons(updated.result);
+  const { npcBattle } = inProgress;
+  const npcBattleResult = getNPCBattleResult(npcBattle.state, gameEnd.result);
+  const updatedState = updateNPCBattleState(npcBattle.state, npcBattleResult);
+  const buttons = postNPCBattleButtons(npcBattleResult);
   await domFloaters.showPostBattle({ ...props, buttons });
   return {
     ...inProgress,
-    npcBattle: { ...inProgress.npcBattle, state: updated.state },
+    npcBattle: { ...inProgress.npcBattle, state: updatedState },
   };
 }

--- a/src/js/game/npc-battle/npc-battle-result.ts
+++ b/src/js/game/npc-battle/npc-battle-result.ts
@@ -1,21 +1,31 @@
+import { GameEndResult } from "gbraver-burst-core";
+
+import { NPCBattleState } from "./npc-battle-state";
+
 /** NPCバトル結果 */
 export type NPCBattleResult = "StageClear" | "StageMiss" | "NPCBattleComplete";
 
 /**
  * NPCバトル結果を求める
- * @param isStageClear ステージクリアしたか否かのフラグ、trueでステージクリア
- * @param isLastStage ラストステージか否かのフラグ、trueでラストステージ
+ * @param origin 更新前のステート
+ * @param gameEndResult 戦闘結果
  * @returns 判定結果
  */
 export function getNPCBattleResult(
-  isStageClear: boolean,
-  isLastStage: boolean,
+  origin: Readonly<NPCBattleState>,
+  gameEndResult: Readonly<GameEndResult>,
 ): NPCBattleResult {
+  const isStageClear =
+    gameEndResult.type === "GameOver" &&
+    gameEndResult.winner === origin.player.playerId;
+  const isLastStage = origin.stageIndex === origin.stages.length - 1;
+
+  let result: NPCBattleResult = "StageMiss";
   if (isStageClear && isLastStage) {
-    return "NPCBattleComplete";
+    result = "NPCBattleComplete";
   } else if (isStageClear && !isLastStage) {
-    return "StageClear";
+    result = "StageClear";
   }
 
-  return "StageMiss";
+  return result;
 }

--- a/src/js/game/npc-battle/updated-npc-battle-state.ts
+++ b/src/js/game/npc-battle/updated-npc-battle-state.ts
@@ -11,7 +11,9 @@ export function updateNPCBattleState(
   origin: Readonly<NPCBattleState>,
   result: NPCBattleResult,
 ): NPCBattleState {
-  const nextStageIndex =
-    result === "StageClear" ? origin.stageIndex + 1 : origin.stageIndex;
+  const nextStageIndex = Math.min(
+    result === "StageClear" ? origin.stageIndex + 1 : origin.stageIndex,
+    origin.stages.length - 1,
+  );
   return { ...origin, stageIndex: nextStageIndex };
 }

--- a/src/js/game/npc-battle/updated-npc-battle-state.ts
+++ b/src/js/game/npc-battle/updated-npc-battle-state.ts
@@ -1,26 +1,17 @@
 import { NPCBattleResult } from "./npc-battle-result";
 import { NPCBattleState } from "./npc-battle-state";
 
-/** NPCバトル更新結果 */
-export type UpdatedNPCBattleState = {
-  /** 更新されたステート */
-  readonly state: NPCBattleState;
-  /** NPCバトル結果 */
-  readonly result: NPCBattleResult;
-};
-
 /**
  * NPCバトルステートを更新する
  * @param origin 更新前のステート
  * @param npcBattleResult NPCバトル結果
- * @returns NPCバトル更新結果
+ * @returns 更新後のステート
  */
 export function updateNPCBattleState(
   origin: Readonly<NPCBattleState>,
   result: NPCBattleResult,
-): UpdatedNPCBattleState | null {
+): NPCBattleState {
   const nextStageIndex =
     result === "StageClear" ? origin.stageIndex + 1 : origin.stageIndex;
-  const state = { ...origin, stageIndex: nextStageIndex };
-  return { state, result };
+  return { ...origin, stageIndex: nextStageIndex };
 }

--- a/src/js/game/npc-battle/updated-npc-battle-state.ts
+++ b/src/js/game/npc-battle/updated-npc-battle-state.ts
@@ -1,42 +1,26 @@
-import { GameEndResult } from "gbraver-burst-core";
-
-import { getCurrentNPCStage } from "./get-current-npc-stage";
-import { getNPCBattleResult, NPCBattleResult } from "./npc-battle-result";
+import { NPCBattleResult } from "./npc-battle-result";
 import { NPCBattleState } from "./npc-battle-state";
 
 /** NPCバトル更新結果 */
 export type UpdatedNPCBattleState = {
   /** 更新されたステート */
-  state: NPCBattleState;
+  readonly state: NPCBattleState;
   /** NPCバトル結果 */
-  result: NPCBattleResult;
+  readonly result: NPCBattleResult;
 };
 
 /**
  * NPCバトルステートを更新する
  * @param origin 更新前のステート
- * @param gameEndResult 戦闘結果
+ * @param npcBattleResult NPCバトル結果
  * @returns NPCバトル更新結果
  */
 export function updateNPCBattleState(
   origin: Readonly<NPCBattleState>,
-  gameEndResult: Readonly<GameEndResult>,
+  result: NPCBattleResult,
 ): UpdatedNPCBattleState | null {
-  const stage = getCurrentNPCStage(origin);
-  if (!stage) {
-    return null;
-  }
-
-  const isStageClear =
-    gameEndResult.type === "GameOver" &&
-    gameEndResult.winner === origin.player.playerId;
-  const isLastStage = origin.stageIndex === origin.stages.length - 1;
-  const result = getNPCBattleResult(isStageClear, isLastStage);
   const nextStageIndex =
     result === "StageClear" ? origin.stageIndex + 1 : origin.stageIndex;
-  const updatedState = { ...origin, stageIndex: nextStageIndex };
-  return {
-    state: updatedState,
-    result,
-  };
+  const state = { ...origin, stageIndex: nextStageIndex };
+  return { state, result };
 }

--- a/test/js/game/npc-battle/get-npc-battle-result.test.ts
+++ b/test/js/game/npc-battle/get-npc-battle-result.test.ts
@@ -1,0 +1,57 @@
+import { EMPTY_PLAYER } from "gbraver-burst-core";
+
+import { getNPCBattleResult } from "../../../../src/js/game/npc-battle/npc-battle-result";
+import { DefaultStage } from "../../../../src/js/game/npc-battle/stages/default-stage";
+
+/** テストプレイヤー情報 */
+const player = { ...EMPTY_PLAYER, playerId: "npc-battle-player" };
+
+/** ステージ情報 */
+const stages = [DefaultStage, DefaultStage, DefaultStage];
+
+test("プレイヤーが勝利した場合はステージクリアである", () => {
+  const state = { player, stages, stageIndex: 0 };
+  expect(
+    getNPCBattleResult(state, {
+      type: "GameOver",
+      winner: "npc-battle-player",
+    }),
+  ).toEqual("StageClear");
+});
+
+test("プレイヤーが敗北した場合はステージミスである", () => {
+  const state = { player, stages, stageIndex: 0 };
+  expect(
+    getNPCBattleResult(state, { type: "GameOver", winner: "enemy" }),
+  ).toEqual("StageMiss");
+});
+
+test("引き分けの場合はステージミスである", () => {
+  const state = { player, stages, stageIndex: 0 };
+  expect(getNPCBattleResult(state, { type: "EvenMatch" })).toEqual("StageMiss");
+});
+
+test("最終ステージでプレイヤーが勝利した場合はNPCバトルコンプリートとなる", () => {
+  const state = { player, stages, stageIndex: 2 };
+  expect(
+    getNPCBattleResult(state, {
+      type: "GameOver",
+      winner: "npc-battle-player",
+    }),
+  ).toEqual("NPCBattleComplete");
+});
+
+test("最終ステージでプレイヤーが敗北した場合でもステージミスである", () => {
+  const state = { player, stages, stageIndex: 2 };
+  expect(
+    getNPCBattleResult(state, {
+      type: "GameOver",
+      winner: "enemy",
+    }),
+  ).toEqual("StageMiss");
+});
+
+test("最終ステージで引き分けた場合でもステージミスである", () => {
+  const state = { player, stages, stageIndex: 2 };
+  expect(getNPCBattleResult(state, { type: "EvenMatch" })).toEqual("StageMiss");
+});

--- a/test/js/game/npc-battle/update-npc-battle-state.test.ts
+++ b/test/js/game/npc-battle/update-npc-battle-state.test.ts
@@ -3,119 +3,31 @@ import { EMPTY_PLAYER } from "gbraver-burst-core";
 import { DefaultStage } from "../../../../src/js/game/npc-battle/stages/default-stage";
 import { updateNPCBattleState } from "../../../../src/js/game/npc-battle/updated-npc-battle-state";
 
+/** テストプレイヤー情報 */
 const player = { ...EMPTY_PLAYER, playerId: "npc-battle-player" };
+
+/** ステージ情報 */
 const stages = [DefaultStage, DefaultStage, DefaultStage];
 
-test("ステージクリアの処理が正しい", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 0,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "GameOver",
-      winner: player.playerId,
-    }),
-  ).toEqual({
-    state: { ...state, stageIndex: 1 },
-    result: "StageClear",
+test("ステージクリアしたらインデックスに+1される", () => {
+  const state = { player, stages, stageIndex: 0 };
+  expect(updateNPCBattleState(state, "StageClear")).toEqual({
+    ...state,
+    stageIndex: 1,
   });
 });
 
-test("ステージミスの処理が正しい", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 0,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "GameOver",
-      winner: "not-player",
-    }),
-  ).toEqual({
-    state,
-    result: "StageMiss",
-  });
+test("ステージミスしたらステートは変わらない", () => {
+  const state = { player, stages, stageIndex: 0 };
+  expect(updateNPCBattleState(state, "StageMiss")).toEqual(state);
 });
 
-test("引き分けはステージミスとみなす", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 0,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "EvenMatch",
-    }),
-  ).toEqual({
-    state,
-    result: "StageMiss",
-  });
+test("最終ステージをクリアしてもインデックスに+1されず、結果としてステートは変わらない", () => {
+  const state = { player, stages, stageIndex: 2 };
+  expect(updateNPCBattleState(state, "StageClear")).toEqual(state);
 });
 
-test("最終ステージクリアの処理が正しい", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 2,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "GameOver",
-      winner: player.playerId,
-    }),
-  ).toEqual({
-    state,
-    result: "NPCBattleComplete",
-  });
-});
-
-test("最終ステージミスの処理が正しい", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 2,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "GameOver",
-      winner: "not-player",
-    }),
-  ).toEqual({
-    state,
-    result: "StageMiss",
-  });
-});
-
-test("最終ステージでも引き分けはミスとみなす", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 2,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "EvenMatch",
-    }),
-  ).toEqual({
-    state,
-    result: "StageMiss",
-  });
-});
-
-test("ステート不整合の場合はnullを返す", () => {
-  const state = {
-    player,
-    stages,
-    stageIndex: 4,
-  };
-  expect(
-    updateNPCBattleState(state, {
-      type: "GameOver",
-      winner: player.playerId,
-    }),
-  ).toEqual(null);
+test("最終ステージでミスをしてもステートは変わらない", () => {
+  const state = { player, stages, stageIndex: 2 };
+  expect(updateNPCBattleState(state, "StageMiss")).toEqual(state);
 });


### PR DESCRIPTION
This pull request introduces significant changes to the NPC battle system in the game. The main changes include refactoring the NPC battle result computation, updating the NPC battle state, and enhancing the test coverage for these functionalities.

Refactoring NPC battle result computation and state update:

* [`src/js/game/game-procedure/on-game-action/on-end-battle/execute-post-npc-battle.ts`](diffhunk://#diff-5c64ccf61c91d9df15a9d2366985a5cbd5802b1f51d37713386c2640c6550f6eL11-R14): Refactored to use `getNPCBattleResult` for determining the battle result and simplified the state update logic. [[1]](diffhunk://#diff-5c64ccf61c91d9df15a9d2366985a5cbd5802b1f51d37713386c2640c6550f6eL11-R14) [[2]](diffhunk://#diff-5c64ccf61c91d9df15a9d2366985a5cbd5802b1f51d37713386c2640c6550f6eL49-R59)
* [`src/js/game/npc-battle/npc-battle-result.ts`](diffhunk://#diff-e5e9c1478e1f84874b932a64939542309cd84e22b84a024c34e2984bc54f7ae7R1-R30): Introduced `getNPCBattleResult` function to compute the NPC battle result based on the game state and end result.
* [`src/js/game/npc-battle/updated-npc-battle-state.ts`](diffhunk://#diff-f3a7befac40d7a74675fe696d295afb0c6500d6a625cd605529154f9b67e0d2eL1-R18): Simplified the `updateNPCBattleState` function to only update the stage index based on the NPC battle result.

Enhancing test coverage:

* [`test/js/game/npc-battle/get-npc-battle-result.test.ts`](diffhunk://#diff-31b29f79678611dee4c1e11d9d72506e3cbd8d740757551e46067bb38885e4b8R1-R57): Added comprehensive tests for `getNPCBattleResult` to cover various game end scenarios.
* [`test/js/game/npc-battle/update-npc-battle-state.test.ts`](diffhunk://#diff-ba9e3821524efc280b42b0b1155d2426be6c01935241a43ec669cc0bd4d763e2R6-R32): Updated tests to reflect changes in the `updateNPCBattleState` function and ensure correct state updates.