### PR TITLE
JSDocを修正

### DIFF
--- a/src/js/game/in-progress/story.ts
+++ b/src/js/game/in-progress/story.ts
@@ -12,7 +12,10 @@ export type PlayingEpisode = {
   readonly episode: Episode;
 };
 
-/** 次のエピソードに進む */
+/**
+ * 次のエピソードに進む準備
+ * ステージクリアなど次エピソードにすすむことが確定した時に、本ステートに遷移する
+ */
 export type GoingNextEpisode = {
   type: "GoingNextEpisode";
   /** 現在のエピソード */


### PR DESCRIPTION
This pull request includes a documentation update to the `GoingNextEpisode` type in the `src/js/game/in-progress/story.ts` file. The update provides a more detailed description of the type's purpose and when it should be used.

Documentation update:

* [`src/js/game/in-progress/story.ts`](diffhunk://#diff-1c8a84a9297c140e5fb390bdfbbd28c8d50e7f397de62f4995ae1ff00b1aec2cL15-R18): Updated the comment for the `GoingNextEpisode` type to clarify that it represents the state transition when progressing to the next episode, such as after clearing a stage.