### PR TITLE
バトル終了時にハンバーガーメニューを消すようにした

### DIFF
--- a/src/js/td-scenes/battle/procedure/progress-game.ts
+++ b/src/js/td-scenes/battle/procedure/progress-game.ts
@@ -53,6 +53,7 @@ const onGameEnd = async (
   props: Readonly<BattleSceneProps>,
   gameEnd: GameEnd,
 ): Promise<void> => {
+  props.view.dom.hamburgerMenu.hidden();
   await props.bgm.do(fadeOut);
   await props.bgm.do(stop);
   props.endBattle.next({


### PR DESCRIPTION
This pull request includes a small change to the `src/js/td-scenes/battle/procedure/progress-game.ts` file. The change hides the hamburger menu when the game ends.

* [`src/js/td-scenes/battle/procedure/progress-game.ts`](diffhunk://#diff-e91db6c1ae92a724e58260dab7b436638d8ac051d49f464613de3350139a376cR56): Added a call to `props.view.dom.hamburgerMenu.hidden()` in the `onGameEnd` function to hide the hamburger menu when the game ends.