### PR TITLE
おおきいボタンを押した時にハンバーガーメニューを閉じるようにした

### DIFF
--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts
@@ -28,9 +28,9 @@ export function onBattleSceneAction(
   } else if (action.type === "decideBattery") {
     onDecideBattery(props, action);
   } else if (action.type === "doBurst") {
-    onBurst(props, action);
+    onBurst(props);
   } else if (action.type === "doPilotSkill") {
-    onPilotSkill(props, action);
+    onPilotSkill(props);
   } else if (action.type === "toggleTimeScale") {
     onToggleTimeScale(props, action);
   } else if (action.type === "decideBatteryByMiniController") {

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
@@ -1,6 +1,5 @@
 import { BurstCommand } from "gbraver-burst-core";
 
-import { DoBurst } from "../../actions/do-burst";
 import { decisionByBurstButton } from "../../animation/decision-by-burst-button";
 import { createAnimationPlay } from "../../play-animation";
 import { BattleSceneProps } from "../../props";
@@ -9,17 +8,11 @@ import { progressGame } from "../progress-game";
 
 /**
  * バースト時の処理
- *
  * @param props 戦闘シーンプロパティ
- * @param action バースト発動アクション
  * @returns 処理が完了したら発火するPromise
  */
-export function onBurst(
-  props: Readonly<BattleSceneProps>,
-  action: DoBurst,
-): void {
+export function onBurst(props: Readonly<BattleSceneProps>): void {
   props.exclusive.execute(async () => {
-    action.event.stopPropagation();
     const burstCommand: BurstCommand = {
       type: "BURST_COMMAND",
     };

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
@@ -19,7 +19,6 @@ export function onDecideBattery(
   action: DecideBattery,
 ): void {
   props.exclusive.execute(async (): Promise<void> => {
-    action.event.stopPropagation();
     const batteryCommand: BatteryCommand = {
       type: "BATTERY_COMMAND",
       battery: action.battery,

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
@@ -1,6 +1,5 @@
 import { PilotSkillCommand } from "gbraver-burst-core";
 
-import { DoPilotSkill } from "../../actions/do-pilot-skill";
 import { decisionByPilotButton } from "../../animation/decision-by-pilot-button";
 import { createAnimationPlay } from "../../play-animation";
 import { BattleSceneProps } from "../../props";
@@ -9,17 +8,11 @@ import { progressGame } from "../progress-game";
 
 /**
  * パイロットスキル発動時の処理
- *
  * @param props 戦闘シーンプロパティ
- * @param action パイロットスキル発動アクション
  * @returns 処理が完了したら発火するPromise
  */
-export function onPilotSkill(
-  props: Readonly<BattleSceneProps>,
-  action: DoPilotSkill,
-): void {
+export function onPilotSkill(props: Readonly<BattleSceneProps>): void {
   props.exclusive.execute(async () => {
-    action.event.stopPropagation();
     const pilotSkillCommand: PilotSkillCommand = {
       type: "PILOT_SKILL_COMMAND",
     };


### PR DESCRIPTION
This pull request includes several changes to the battle scene action handlers in the `src/js/td-scenes/battle/procedure/on-battle-scene-action/` directory. The main focus of these changes is to simplify the function signatures by removing the `action` parameter from certain functions and updating their corresponding calls.

Function signature simplifications:

* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts`](diffhunk://#diff-95e1a8a01acf6a620942f9111015bbd1b84873807b48b79d839caa1a496b0accL31-R33): Removed the `action` parameter from the `onBurst` and `onPilotSkill` function calls.
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts`](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edL3): Updated the `onBurst` function to remove the `action` parameter and its usage. [[1]](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edL3) [[2]](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edL12-L22)
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts`](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cL3): Updated the `onPilotSkill` function to remove the `action` parameter and its usage. [[1]](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cL3) [[2]](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cL12-L22)
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts`](diffhunk://#diff-12a2621403332f62a78c8937f5b7fb724cc0b9270dd3f98a59b91ff1c397f40cL22): Removed the `action.event.stopPropagation()` call from the `onDecideBattery` function.