### PR TITLE
ストーリーモードをハンバーガーメニューから終了した時にストーリーが選択できなくなる不具合を修正

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
@@ -123,7 +123,7 @@ export async function onForceEndBattle(options: ForceEndBattleOptions) {
       props.inProgress = { type: "Story", story: { type: "EpisodeSelect" } };
       break;
     default:
-      forceEndBattle(props);
+      await forceEndBattle(props);
       props.inProgress = { type: "None" };
       break;
   }

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle.ts
@@ -116,14 +116,15 @@ export async function onForceEndBattle(options: ForceEndBattleOptions) {
     case "PrivateMatchHost":
     case "PrivateMatchGuest":
       await forceEndNetBattle({ ...props, inProgress });
+      props.inProgress = { type: "None" };
       break;
     case "Story":
       await forceEndStoryBattle({ ...props, inProgress });
+      props.inProgress = { type: "Story", story: { type: "EpisodeSelect" } };
       break;
     default:
       forceEndBattle(props);
+      props.inProgress = { type: "None" };
       break;
   }
-
-  props.inProgress = { type: "None" };
 }

--- a/src/js/game/game-procedure/on-game-action/on-select-episode.ts
+++ b/src/js/game/game-procedure/on-game-action/on-select-episode.ts
@@ -29,10 +29,7 @@ export async function onSelectEpisode(options: Options): Promise<void> {
   const episode = episodes.find((v) => v.id === action.id) ?? episodes[0];
   props.inProgress = {
     ...inProgress,
-    story: {
-      type: "PlayingEpisode",
-      episode,
-    },
+    story: { type: "PlayingEpisode", episode },
   };
   await startEpisode(props, episode);
 }


### PR DESCRIPTION
This pull request includes updates to the game procedure functions to properly set the `inProgress` property after specific game actions are executed. The changes ensure that the `inProgress` state is correctly updated based on the type of battle or episode selection.

Updates to game procedure functions:

* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674R119-L128): Modified the `onForceEndBattle` function to set the `inProgress` property to `{ type: "None" }` after ending private matches and default battles, and to `{ type: "Story", story: { type: "EpisodeSelect" } }` after ending story battles.
* [`src/js/game/game-procedure/on-game-action/on-select-episode.ts`](diffhunk://#diff-e67eb02f8bcb5e29c0159e5d069801dd07058400453a045fc7f7491377db3a52L32-R32): Updated the `onSelectEpisode` function to set the `inProgress.story` property to `{ type: "PlayingEpisode", episode }` in a more concise format.