### PR TITLE
ミニコントローラーのサイズを大きくした

### DIFF
--- a/src/css/mini-controller.css
+++ b/src/css/mini-controller.css
@@ -10,7 +10,7 @@
     --button-font-color: var(--font-color);
     --button-border-radius: calc(var(--dialog-border-radius) * 0.5);
 
-    min-width: calc(var(--responsive-font-size) * 15);
+    min-width: calc(var(--responsive-font-size) * 28);
     position: fixed;
     bottom: max(calc(var(--responsive-font-size) * 1), var(--safe-area-bottom));
     right: max(calc(var(--responsive-font-size) * 1), var(--safe-area-right));


### PR DESCRIPTION
This pull request includes a change to the `src/css/mini-controller.css` file. The change increases the minimum width of the mini-controller to improve its responsiveness on various screen sizes.

* [`src/css/mini-controller.css`](diffhunk://#diff-52bfe328c4162158d0edc47cfd698ba3af9190019fbaec9a6d86b4d4ae9599fcL13-R13): Increased the `min-width` property from `calc(var(--responsive-font-size) * 15)` to `calc(var(--responsive-font-size) * 28)` to enhance the layout and responsiveness.