### PR TITLE
おおきいボタンを押したらメッセージが即送りされる不具合を解消した

### DIFF
--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts
@@ -28,9 +28,9 @@ export function onBattleSceneAction(
   } else if (action.type === "decideBattery") {
     onDecideBattery(props, action);
   } else if (action.type === "doBurst") {
-    onBurst(props);
+    onBurst(props, action);
   } else if (action.type === "doPilotSkill") {
-    onPilotSkill(props);
+    onPilotSkill(props, action);
   } else if (action.type === "toggleTimeScale") {
     onToggleTimeScale(props, action);
   } else if (action.type === "decideBatteryByMiniController") {

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
@@ -1,5 +1,6 @@
 import { BurstCommand } from "gbraver-burst-core";
 
+import { DoBurst } from "../../actions/do-burst";
 import { decisionByBurstButton } from "../../animation/decision-by-burst-button";
 import { createAnimationPlay } from "../../play-animation";
 import { BattleSceneProps } from "../../props";
@@ -8,11 +9,17 @@ import { progressGame } from "../progress-game";
 
 /**
  * バースト時の処理
+ *
  * @param props 戦闘シーンプロパティ
+ * @param action バースト発動アクション
  * @returns 処理が完了したら発火するPromise
  */
-export function onBurst(props: Readonly<BattleSceneProps>): void {
+export function onBurst(
+  props: Readonly<BattleSceneProps>,
+  action: DoBurst,
+): void {
   props.exclusive.execute(async () => {
+    action.event.stopPropagation();
     const burstCommand: BurstCommand = {
       type: "BURST_COMMAND",
     };

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
@@ -19,6 +19,7 @@ export function onDecideBattery(
   action: DecideBattery,
 ): void {
   props.exclusive.execute(async (): Promise<void> => {
+    action.event.stopPropagation();
     const batteryCommand: BatteryCommand = {
       type: "BATTERY_COMMAND",
       battery: action.battery,

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
@@ -1,5 +1,6 @@
 import { PilotSkillCommand } from "gbraver-burst-core";
 
+import { DoPilotSkill } from "../../actions/do-pilot-skill";
 import { decisionByPilotButton } from "../../animation/decision-by-pilot-button";
 import { createAnimationPlay } from "../../play-animation";
 import { BattleSceneProps } from "../../props";
@@ -8,11 +9,17 @@ import { progressGame } from "../progress-game";
 
 /**
  * パイロットスキル発動時の処理
+ *
  * @param props 戦闘シーンプロパティ
+ * @param action パイロットスキル発動アクション
  * @returns 処理が完了したら発火するPromise
  */
-export function onPilotSkill(props: Readonly<BattleSceneProps>): void {
+export function onPilotSkill(
+  props: Readonly<BattleSceneProps>,
+  action: DoPilotSkill,
+): void {
   props.exclusive.execute(async () => {
+    action.event.stopPropagation();
     const pilotSkillCommand: PilotSkillCommand = {
       type: "PILOT_SKILL_COMMAND",
     };


### PR DESCRIPTION
This pull request includes several updates to the battle scene action handlers in the project, specifically to ensure that the `action` parameter is passed correctly and that the event propagation is stopped. The most important changes include modifications to the `onBurst`, `onPilotSkill`, and `onDecideBattery` functions, as well as the necessary imports for the new action types.

Changes to function parameters and event handling:

* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/index.ts`](diffhunk://#diff-95e1a8a01acf6a620942f9111015bbd1b84873807b48b79d839caa1a496b0accL31-R33): Updated `onBurst` and `onPilotSkill` functions to accept the `action` parameter.
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts`](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edR3): Modified `onBurst` function to include the `action` parameter and added `action.event.stopPropagation()` to stop event propagation. [[1]](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edR3) [[2]](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edR12-R22)
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts`](diffhunk://#diff-12a2621403332f62a78c8937f5b7fb724cc0b9270dd3f98a59b91ff1c397f40cR22): Added `action.event.stopPropagation()` in the `onDecideBattery` function to stop event propagation.
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts`](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cR3): Modified `onPilotSkill` function to include the `action` parameter and added `action.event.stopPropagation()` to stop event propagation. [[1]](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cR3) [[2]](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cR12-R22)