### PR TITLE
おおきいボタンを押したらハンバーガーメニューを閉じるようにした

### DIFF
--- a/src/js/game-dom/battle-hamburger-menu/index.ts
+++ b/src/js/game-dom/battle-hamburger-menu/index.ts
@@ -1,6 +1,7 @@
 import { Observable, Unsubscribable } from "rxjs";
 
 import { bindEventListeners } from "./procedure/bind-event-listeners";
+import { close } from "./procedure/close";
 import {
   BattleHamburgerMenuPropsCreatorParams,
   createBattleHamburgerMenuProps,
@@ -42,6 +43,13 @@ export class BattleHamburgerMenu {
    */
   hidden() {
     hidden(this.#props);
+  }
+
+  /**
+   * メニューを閉じる
+   */
+  close() {
+    close(this.#props);
   }
 
   /**

--- a/src/js/game-dom/battle-hamburger-menu/procedure/close.ts
+++ b/src/js/game-dom/battle-hamburger-menu/procedure/close.ts
@@ -1,0 +1,12 @@
+import { MENU_HIDDEN } from "../dom/class-name";
+import { BattleHamburgerMenuProps } from "../props";
+
+/**
+ * メニューを閉じる
+ * @param props プロパティ
+ */
+export function close(props: BattleHamburgerMenuProps) {
+  props.exclusive.execute(async () => {
+    props.menu.className = MENU_HIDDEN;
+  });
+}

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts
@@ -20,6 +20,7 @@ export function onBurst(
 ): void {
   props.exclusive.execute(async () => {
     action.event.stopPropagation();
+    props.view.dom.hamburgerMenu.close();
     const burstCommand: BurstCommand = {
       type: "BURST_COMMAND",
     };

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts
@@ -20,6 +20,7 @@ export function onDecideBattery(
 ): void {
   props.exclusive.execute(async (): Promise<void> => {
     action.event.stopPropagation();
+    props.view.dom.hamburgerMenu.close();
     const batteryCommand: BatteryCommand = {
       type: "BATTERY_COMMAND",
       battery: action.battery,

--- a/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
+++ b/src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts
@@ -20,6 +20,7 @@ export function onPilotSkill(
 ): void {
   props.exclusive.execute(async () => {
     action.event.stopPropagation();
+    props.view.dom.hamburgerMenu.close();
     const pilotSkillCommand: PilotSkillCommand = {
       type: "PILOT_SKILL_COMMAND",
     };


### PR DESCRIPTION
This pull request introduces a new method to close the battle hamburger menu and integrates it into various battle scene actions. The most important changes include the addition of the `close` method in the `BattleHamburgerMenu` class and its usage in different battle procedures.

Enhancements to `BattleHamburgerMenu`:

* [`src/js/game-dom/battle-hamburger-menu/index.ts`](diffhunk://#diff-855711f8f226a48071d17d68cef770ed672776a68bea04f8a329020507a4efc3R48-R54): Added the `close` method to the `BattleHamburgerMenu` class to allow closing the menu.
* [`src/js/game-dom/battle-hamburger-menu/procedure/close.ts`](diffhunk://#diff-c30d5f74a1a91cd05d651e1790063ed2dd266e11bb06b6bcbb11a309a3e4a79cR1-R12): Created a new `close` function to handle the logic for closing the menu by updating the class name to `MENU_HIDDEN`.

Integration into battle scene actions:

* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-burst.ts`](diffhunk://#diff-df347d2c52fd9e6064572eead3c102b83272d804e7047b6f99d5cab0c96417edR23): Updated the `onBurst` function to call `props.view.dom.hamburgerMenu.close()` to close the menu when a burst action is triggered.
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-decide-battery.ts`](diffhunk://#diff-12a2621403332f62a78c8937f5b7fb724cc0b9270dd3f98a59b91ff1c397f40cR23): Updated the `onDecideBattery` function to call `props.view.dom.hamburgerMenu.close()` to close the menu when a battery action is decided.
* [`src/js/td-scenes/battle/procedure/on-battle-scene-action/on-pilot-skill.ts`](diffhunk://#diff-56864e19a469d57432b51c9b1121f329efa7750294676aad438fe84e4e08e90cR23): Updated the `onPilotSkill` function to call `props.view.dom.hamburgerMenu.close()` to close the menu when a pilot skill action is triggered.