### PR TITLE
バーストアニメーションの分岐ロジックをリファクタリングした

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/burst/genesis-braver.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/genesis-braver.ts
@@ -84,10 +84,11 @@ function batteryLimitBreak(
  * @returns アニメーション
  */
 export function genesisBraverBurst(param: GenesisBraverBurst<Burst>): Animate {
-  if (param.burst.type === "BatteryLimitBreak") {
-    const burst: BatteryLimitBreak = param.burst;
-    return batteryLimitBreak({ ...param, burst });
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "BatteryLimitBreak") {
+    ret = batteryLimitBreak({ ...param, burst });
   }
 
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/burst/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/index.ts
@@ -33,12 +33,7 @@ export function burstAnimation(
   gameState: GameStateX<BurstEffect>,
 ): Animate {
   const param = toBurstAnimationParam(props, gameState);
-
-  if (!param) {
-    return empty();
-  }
-
-  return armdozerAnimation(param);
+  return param ? armdozerAnimation(param) : empty();
 }
 
 /**
@@ -48,50 +43,34 @@ export function burstAnimation(
  * @returns バーストアニメーション
  */
 function armdozerAnimation(param: BurstAnimationParam): Animate {
+  const { burstArmdozerTD, burstArmdozerHUD } = param;
+  let ret = empty();
   if (
-    param.burstArmdozerTD instanceof ShinBraverTD &&
-    param.burstArmdozerHUD instanceof ShinBraverHUD
+    burstArmdozerTD instanceof ShinBraverTD &&
+    burstArmdozerHUD instanceof ShinBraverHUD
   ) {
-    const burstArmdozerTD: ShinBraverTD = param.burstArmdozerTD;
-    const burstArmdozerHUD: ShinBraverHUD = param.burstArmdozerHUD;
-    return shinBraverBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+    ret = shinBraverBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+  } else if (
+    burstArmdozerTD instanceof NeoLandozerTD &&
+    burstArmdozerHUD instanceof NeoLandozerHUD
+  ) {
+    ret = neoLandozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+  } else if (
+    burstArmdozerTD instanceof LightningDozerTD &&
+    burstArmdozerHUD instanceof LightningDozerHUD
+  ) {
+    ret = lightningDozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+  } else if (
+    burstArmdozerTD instanceof WingDozerTD &&
+    burstArmdozerHUD instanceof WingDozerHUD
+  ) {
+    ret = wingDozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+  } else if (
+    burstArmdozerTD instanceof GenesisBraverTD &&
+    burstArmdozerHUD instanceof GenesisBraverHUD
+  ) {
+    ret = genesisBraverBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
   }
 
-  if (
-    param.burstArmdozerTD instanceof NeoLandozerTD &&
-    param.burstArmdozerHUD instanceof NeoLandozerHUD
-  ) {
-    const burstArmdozerTD: NeoLandozerTD = param.burstArmdozerTD;
-    const burstArmdozerHUD: NeoLandozerHUD = param.burstArmdozerHUD;
-    return neoLandozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
-  }
-
-  if (
-    param.burstArmdozerTD instanceof LightningDozerTD &&
-    param.burstArmdozerHUD instanceof LightningDozerHUD
-  ) {
-    const burstArmdozerTD: LightningDozerTD = param.burstArmdozerTD;
-    const burstArmdozerHUD: LightningDozerHUD = param.burstArmdozerHUD;
-    return lightningDozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
-  }
-
-  if (
-    param.burstArmdozerTD instanceof WingDozerTD &&
-    param.burstArmdozerHUD instanceof WingDozerHUD
-  ) {
-    const burstArmdozerTD: WingDozerTD = param.burstArmdozerTD;
-    const burstArmdozerHUD: WingDozerHUD = param.burstArmdozerHUD;
-    return wingDozerBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
-  }
-
-  if (
-    param.burstArmdozerTD instanceof GenesisBraverTD &&
-    param.burstArmdozerHUD instanceof GenesisBraverHUD
-  ) {
-    const burstArmdozerTD: GenesisBraverTD = param.burstArmdozerTD;
-    const burstArmdozerHUD: GenesisBraverHUD = param.burstArmdozerHUD;
-    return genesisBraverBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
-  }
-
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/burst/lightning-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/lightning-dozer.ts
@@ -92,10 +92,11 @@ function lightningBarrier(
 export function lightningDozerBurst(
   param: LightningDozerBurst<Burst>,
 ): Animate {
-  if (param.burst.type === "LightningBarrier") {
-    const burst: LightningBarrier = param.burst;
-    return lightningBarrier({ ...param, burst });
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "LightningBarrier") {
+    ret = lightningBarrier({ ...param, burst });
   }
 
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/burst/neo-landozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/neo-landozer.ts
@@ -83,10 +83,11 @@ function neoLandozerBuffPower(param: NeoLandozerBurst<BuffPower>): Animate {
  * @returns アニメーション
  */
 export function neoLandozerBurst(param: NeoLandozerBurst<Burst>): Animate {
-  if (param.burst.type === "BuffPower") {
-    const burst: BuffPower = param.burst;
-    return neoLandozerBuffPower({ ...param, burst });
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "BuffPower") {
+    ret = neoLandozerBuffPower({ ...param, burst });
   }
 
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/burst/shin-braver.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/shin-braver.ts
@@ -81,10 +81,11 @@ function recoverBattery(param: ShinBraverBurst<RecoverBattery>): Animate {
  * @returns アニメーション
  */
 export function shinBraverBurst(param: ShinBraverBurst<Burst>): Animate {
-  if (param.burst.type === "RecoverBattery") {
-    const burst: RecoverBattery = param.burst;
-    return recoverBattery({ ...param, burst });
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "RecoverBattery") {
+    ret = recoverBattery({ ...param, burst });
   }
 
-  return empty();
+  return ret;
 }

--- a/src/js/td-scenes/battle/animation/game-state/burst/wingdozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/wingdozer.ts
@@ -85,10 +85,11 @@ export function wingDozerContinuousAttack(
  * @returns アニメーション
  */
 export function wingDozerBurst(param: WingDozerBurst<Burst>): Animate {
-  if (param.burst.type === "ContinuousAttack") {
-    const burst: ContinuousAttack = param.burst;
-    return wingDozerContinuousAttack({ ...param, burst });
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "ContinuousAttack") {
+    ret = wingDozerContinuousAttack({ ...param, burst });
   }
 
-  return empty();
+  return ret;
 }


### PR DESCRIPTION
This pull request focuses on refactoring and simplifying the animation functions for various burst types in the `src/js/td-scenes/battle/animation/game-state/burst` directory. The main changes involve optimizing return statements and reducing code redundancy.

Refactoring and simplification:

* [`src/js/td-scenes/battle/animation/game-state/burst/genesis-braver.ts`](diffhunk://#diff-e5d0d17dc028b6e9ccc52a6c7c6353ca8ebd7074f2d37b0670c1232f6703e920L87-R93): Modified `genesisBraverBurst` to use a single return statement and a temporary variable for the result.
* [`src/js/td-scenes/battle/animation/game-state/burst/index.ts`](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffL36-R36): Simplified `burstAnimation` by using a ternary operator and optimized `armdozerAnimation` with a temporary variable and consolidated return statements. [[1]](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffL36-R36) [[2]](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffR46-R75)
* [`src/js/td-scenes/battle/animation/game-state/burst/lightning-dozer.ts`](diffhunk://#diff-4588d10f19f0d130f56dae74b1e1ca73a9cbd7d64d80dc2fea11b6fc19db9e4cL95-R101): Updated `lightningDozerBurst` to use a temporary variable for the result and a single return statement.
* [`src/js/td-scenes/battle/animation/game-state/burst/neo-landozer.ts`](diffhunk://#diff-891e2bc45fa7dbcf10740598fedfe0f0a2e2547033e6e3f551ddc3bea057669bL86-R92): Refactored `neoLandozerBurst` to use a temporary variable for the result and a single return statement.
* [`src/js/td-scenes/battle/animation/game-state/burst/shin-braver.ts`](diffhunk://#diff-12f7db3092971e3f411f028207717fdbf7e4fdaaff54700b4b51a39b4f71c69dL84-R90): Adjusted `shinBraverBurst` to use a temporary variable for the result and a single return statement.
* [`src/js/td-scenes/battle/animation/game-state/burst/wingdozer.ts`](diffhunk://#diff-d538624f7869df38b92a7aa7a7485040b33e4b5f8da9b202a53fb019d261669dL88-R94): Modified `wingDozerBurst` to use a temporary variable for the result and a single return statement.