### PR TITLE
グランドーザのバーストアニメーションを仮作成した

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -43,10 +43,8 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
     focusToBurstPlayer(param),
     param.tdObjects.skyBrightness.brightness(0.2, 500),
     param.tdObjects.illumination.intensity(0.2, 500),
-    param.hudObjects.rearmostFader.opacity(0.6, 500),
     param.attackerArmdozerTD.sprite().endActive(),
   )
-    .chain(delay(800))
     .chain(
       all(
         param.burstPlayerHUD.gauge.battery(

--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -1,0 +1,81 @@
+import { Burst, Ineffective } from "gbraver-burst-core";
+
+import { all } from "../../../../../animation/all";
+import { Animate } from "../../../../../animation/animate";
+import { delay, empty } from "../../../../../animation/delay";
+import { HUDArmdozerObjects } from "../../../view/hud/armdozer-objects/hud-armdozer-objects";
+import { GranDozerTD } from "../../../view/td/armdozer-objects/gran-dozer";
+import { toInitial } from "../../td-camera";
+import { BurstAnimationParamX } from "./animation-param";
+
+/**
+ * グランドーザ バーストアニメーション パラメータ
+ * @template BURST バースト種別
+ */
+export type GranDozerBurst<BURST extends Burst> = BurstAnimationParamX<
+  GranDozerTD,
+  HUDArmdozerObjects, // TODO グランドーザのものに置き換える
+  BURST
+>;
+
+/**
+ * バースト発動側プレイヤーにフォーカスを合わせる
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+function focusToBurstPlayer(param: GranDozerBurst<Burst>) {
+  const duration = 500;
+  const x = param.burstArmdozerTD.granDozer.getObject3D().position.x;
+  const z = "-60";
+  return all(
+    param.tdCamera.move({ x, z }, duration),
+    param.tdCamera.lookAt({ x, z }, duration),
+  );
+}
+
+/**
+ * グランドーザ バッテリー回復 アニメーション
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+function ineffective(param: GranDozerBurst<Ineffective>): Animate {
+  return all(
+    focusToBurstPlayer(param),
+    param.tdObjects.skyBrightness.brightness(0.2, 500),
+    param.tdObjects.illumination.intensity(0.2, 500),
+    param.hudObjects.rearmostFader.opacity(0.6, 500),
+    param.attackerArmdozerTD.sprite().endActive(),
+  )
+    .chain(delay(800))
+    .chain(
+      all(
+        param.burstPlayerHUD.gauge.battery(
+          param.burstPlayerState.armdozer.battery,
+        ),
+        param.burstPlayerTD.recoverBattery.popUp(param.burst.recoverBattery),
+      ),
+    )
+    .chain(
+      all(
+        toInitial(param.tdCamera, 500),
+        param.tdObjects.skyBrightness.brightness(1, 500),
+        param.tdObjects.illumination.intensity(1, 500),
+      ),
+    )
+    .chain(delay(200));
+}
+
+/**
+ * グランドーザ バースト アニメーション
+ * @param param パラメータ
+ * @returns アニメーション
+ */
+export function granDozerBurst(param: GranDozerBurst<Burst>): Animate {
+  const { burst } = param;
+  let ret = empty();
+  if (burst.type === "Ineffective") {
+    ret = ineffective({ ...param, burst });
+  }
+
+  return ret;
+}

--- a/src/js/td-scenes/battle/animation/game-state/burst/index.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/index.ts
@@ -8,14 +8,16 @@ import { NeoLandozerHUD } from "../../../view/hud/armdozer-objects/neo-landozer"
 import { ShinBraverHUD } from "../../../view/hud/armdozer-objects/shin-braver";
 import { WingDozerHUD } from "../../../view/hud/armdozer-objects/wing-dozer";
 import { GenesisBraverTD } from "../../../view/td/armdozer-objects/genesis-braver";
+import { GranDozerTD } from "../../../view/td/armdozer-objects/gran-dozer";
 import { LightningDozerTD } from "../../../view/td/armdozer-objects/lightning-dozer";
 import { NeoLandozerTD } from "../../../view/td/armdozer-objects/neo-landozer";
 import { ShinBraverTD } from "../../../view/td/armdozer-objects/shin-braver";
 import { WingDozerTD } from "../../../view/td/armdozer-objects/wing-dozer";
-import type { StateAnimationProps } from "../state-animation-props";
-import type { BurstAnimationParam } from "./animation-param";
+import { StateAnimationProps } from "../state-animation-props";
+import { BurstAnimationParam } from "./animation-param";
 import { toBurstAnimationParam } from "./animation-param";
 import { genesisBraverBurst } from "./genesis-braver";
+import { granDozerBurst } from "./gran-dozer";
 import { lightningDozerBurst } from "./lightning-dozer";
 import { neoLandozerBurst } from "./neo-landozer";
 import { shinBraverBurst } from "./shin-braver";
@@ -70,6 +72,8 @@ function armdozerAnimation(param: BurstAnimationParam): Animate {
     burstArmdozerHUD instanceof GenesisBraverHUD
   ) {
     ret = genesisBraverBurst({ ...param, burstArmdozerTD, burstArmdozerHUD });
+  } else if (burstArmdozerTD instanceof GranDozerTD) {
+    ret = granDozerBurst({ ...param, burstArmdozerTD });
   }
 
   return ret;


### PR DESCRIPTION
This pull request introduces a new burst animation for the `GranDozer` character in the battle animation module. The main changes include adding the `GranDozer` burst animation logic, integrating it into the existing burst animation flow, and updating the necessary imports.

New burst animation for `GranDozer`:

* [`src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts`](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffR1-R79): Added the `GranDozer` burst animation logic, including functions for focusing on the burst player and handling the ineffective burst animation.

Integration into existing burst animation flow:

* [`src/js/td-scenes/battle/animation/game-state/burst/index.ts`](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffR11-R20): Updated imports to include `GranDozerTD` and added the `granDozerBurst` function to the burst animation handling logic. [[1]](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffR11-R20) [[2]](diffhunk://#diff-83f9d8682aab21ba582612510dd878308475e4895d40dd4c4f97bce779507bffR75-R76)