### PR TITLE
グランドーザの避けモーション仮作成

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/back-step.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/back-step.ts
@@ -1,0 +1,17 @@
+import { Animate } from "../../../../animation/animate";
+import { tween } from "../../../../animation/tween";
+import { GranDozerAnimationProps } from "./animation-props";
+
+/**
+ * 避ける
+ * @param props アニメーションプロパティ
+ * @returns アニメーション
+ */
+export function backStep(props: GranDozerAnimationProps): Animate {
+  const { model, sounds, se } = props;
+  return tween(model.position, (t) =>
+    t.to({ x: "+100" }, 150).onStart(() => {
+      se.play(sounds.motor);
+    }),
+  );
+}

--- a/src/js/game-object/armdozer/gran-dozer/animation/front-step.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/front-step.ts
@@ -1,0 +1,17 @@
+import { Animate } from "../../../../animation/animate";
+import { tween } from "../../../../animation/tween";
+import { GranDozerAnimationProps } from "./animation-props";
+
+/**
+ * フロントステップ
+ * @param props アニメーションプロパティ
+ * @returns アニメーション
+ */
+export function frontStep(props: GranDozerAnimationProps): Animate {
+  const { model, sounds, se } = props;
+  return tween(model.position, (t) =>
+    t.to({ x: "-100" }, 300).onStart(() => {
+      se.play(sounds.motor);
+    }),
+  );
+}

--- a/src/js/game-object/armdozer/gran-dozer/gran-dozer.ts
+++ b/src/js/game-object/armdozer/gran-dozer/gran-dozer.ts
@@ -16,6 +16,8 @@ import {
   GranDozerPropsCreatorOptions,
 } from "./props/create-gran-dozer-props";
 import { GranDozerProps } from "./props/gran-dozer-props";
+import { backStep } from "./animation/back-step";
+import { frontStep } from "./animation/front-step";
 
 /** オプション */
 type Options = GranDozerPropsCreatorOptions & {
@@ -83,6 +85,16 @@ export class GranDozer extends EmptyArmdozerSprite {
    */
   tackleToStand(): Animate {
     return tackleToStand(this.#props);
+  }
+
+  /** @override */
+  avoid(): Animate {
+    return backStep(this.#props);
+  }
+
+  /** @override */
+  avoidToStand(): Animate {
+    return frontStep(this.#props);
   }
 
   /** @override */


### PR DESCRIPTION
This pull request includes new animation functions for the `GranDozer` game object and integrates them into the class. The most important changes include the addition of `backStep` and `frontStep` animation functions, and their integration into the `GranDozer` class.

New animation functions:

* [`src/js/game-object/armdozer/gran-dozer/animation/back-step.ts`](diffhunk://#diff-acf77f8bc8486b6e794c61e2ab1efe1e13dbad5bf196ef781cf3c68ef92f8996R1-R17): Added `backStep` function to handle the back step animation for the `GranDozer` object.
* [`src/js/game-object/armdozer/gran-dozer/animation/front-step.ts`](diffhunk://#diff-6983772a4c205fb9dc5cf05d72b34313a1dca55b9acfe6946c7e79e236b9ae57R1-R17): Added `frontStep` function to handle the front step animation for the `GranDozer` object.

Integration into `GranDozer` class:

* [`src/js/game-object/armdozer/gran-dozer/gran-dozer.ts`](diffhunk://#diff-22b5181371dfe926d0d89d8913d8f0f4e2fe5e4a2c744b6168d143dccaf9f7e6R19-R20): Imported `backStep` and `frontStep` functions.
* [`src/js/game-object/armdozer/gran-dozer/gran-dozer.ts`](diffhunk://#diff-22b5181371dfe926d0d89d8913d8f0f4e2fe5e4a2c744b6168d143dccaf9f7e6R90-R99): Added `avoid` and `avoidToStand` methods to the `GranDozer` class to utilize the new animation functions.