### PR TITLE
グランドーザのバーストアニメを改善

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -44,15 +44,15 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
     param.tdObjects.skyBrightness.brightness(0.2, 500),
     param.tdObjects.illumination.intensity(0.2, 500),
     param.attackerArmdozerTD.sprite().endActive(),
-  )
-    .chain(
+    delay(200).chain(
       all(
         param.burstPlayerHUD.gauge.battery(
           param.burstPlayerState.armdozer.battery,
         ),
         param.burstPlayerTD.recoverBattery.popUp(param.burst.recoverBattery),
       ),
-    )
+    ),
+  )
     .chain(
       all(
         toInitial(param.tdCamera, 500),


### PR DESCRIPTION
This pull request includes a change to the `ineffective` function in the `gran-dozer.ts` file. The change introduces a delay in the animation sequence.

* [`src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts`](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL47-R54): Added a `delay(200)` before chaining the next set of animations.