### PR TITLE
強制バトル終了をリファクタリングした

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
@@ -1,0 +1,25 @@
+import { fadeOut, stop } from "../../../../bgm/bgm-operators";
+import { GameProps } from "../../../game-props";
+import { playTitleBGM } from "../../play-title-bgm";
+import { startTitle } from "../../start-title";
+
+/**
+ * 汎用的なバトル強制終了
+ * @param props ゲームプロパティ
+ * @returns 処理が完了したら発火するPromise
+ */
+export async function forceEndBattle(props: Readonly<GameProps>) {
+  props.domFloaters.hiddenPostBattle();
+  await Promise.all([
+    (async () => {
+      await props.fader.fadeOut();
+      await startTitle(props);
+    })(),
+    (async () => {
+      await props.bgm.do(fadeOut);
+      await props.bgm.do(stop);
+    })(),
+  ]);
+  await props.fader.fadeIn();
+  playTitleBGM(props);
+}

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
@@ -1,0 +1,41 @@
+import { fadeOut, stop } from "../../../../bgm/bgm-operators";
+import { WaitingDialog } from "../../../../dom-dialogs/waiting/waiting-dialog";
+import { GameProps } from "../../../game-props";
+import { CasualMatch } from "../../../in-progress/casual-match";
+import { PrivateMatchGuest } from "../../../in-progress/private-match-guest";
+import { PrivateMatchHost } from "../../../in-progress/private-match-host";
+import { playTitleBGM } from "../../play-title-bgm";
+import { startTitle } from "../../start-title";
+import { switchWaitingDialog } from "../../switch-dialog/switch-waiting-dialog";
+
+/**
+ * ネットバトルを強制終了する
+ * @param props ゲームプロパティ
+ * @returns 処理が完了したら発火するPromise
+ */
+export async function forceEndNetBattle(
+  props: Readonly<
+    GameProps & {
+      inProgress: CasualMatch | PrivateMatchHost | PrivateMatchGuest;
+    }
+  >,
+) {
+  props.domFloaters.hiddenPostBattle();
+
+  const dialog = new WaitingDialog("通信中......");
+  switchWaitingDialog(props, dialog);
+  await props.api.disconnectWebsocket();
+  props.domDialogBinder.hidden();
+  await Promise.all([
+    (async () => {
+      await props.fader.fadeOut();
+      await startTitle(props);
+    })(),
+    (async () => {
+      await props.bgm.do(fadeOut);
+      await props.bgm.do(stop);
+    })(),
+  ]);
+  await props.fader.fadeIn();
+  playTitleBGM(props);
+}

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
@@ -1,0 +1,34 @@
+import { fadeOut, stop } from "../../../../bgm/bgm-operators";
+import { batterySystemTutorial } from "../../../episodes/battery-system-tutorial";
+import { GameProps } from "../../../game-props";
+import { Story } from "../../../in-progress/story";
+import { playTitleBGM } from "../../play-title-bgm";
+import { startEpisodeSelector } from "../../start-episode-selector";
+
+/**
+ * ストーリーモードバトルを強制終了する
+ * @param props ゲームプロパティ
+ * @returns 処理が完了したら発火するPromise
+ */
+export async function forceEndStoryBattle(
+  props: Readonly<GameProps & { inProgress: Story }>,
+) {
+  props.domFloaters.hiddenPostBattle();
+
+  const selectedEpisodeId =
+    props.inProgress.story.type === "PlayingEpisode"
+      ? props.inProgress.story.episode.id
+      : batterySystemTutorial.id;
+  await Promise.all([
+    (async () => {
+      props.domFloaters.hiddenPostBattle();
+      await startEpisodeSelector(props, selectedEpisodeId);
+    })(),
+    (async () => {
+      await props.bgm.do(fadeOut);
+      await props.bgm.do(stop);
+    })(),
+  ]);
+
+  playTitleBGM(props);
+}

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/index.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/index.ts
@@ -1,16 +1,16 @@
-import { fadeOut, stop } from "../../../bgm/bgm-operators";
-import { WaitingDialog } from "../../../dom-dialogs/waiting/waiting-dialog";
-import { batterySystemTutorial } from "../../episodes/battery-system-tutorial";
-import { ForceEndBattle } from "../../game-actions/force-end-battle";
-import { GameProps } from "../../game-props";
-import { CasualMatch } from "../../in-progress/casual-match";
-import { PrivateMatchGuest } from "../../in-progress/private-match-guest";
-import { PrivateMatchHost } from "../../in-progress/private-match-host";
-import { Story } from "../../in-progress/story";
-import { playTitleBGM } from "../play-title-bgm";
-import { startEpisodeSelector } from "../start-episode-selector";
-import { startTitle } from "../start-title";
-import { switchWaitingDialog } from "../switch-dialog/switch-waiting-dialog";
+import { fadeOut, stop } from "../../../../bgm/bgm-operators";
+import { WaitingDialog } from "../../../../dom-dialogs/waiting/waiting-dialog";
+import { batterySystemTutorial } from "../../../episodes/battery-system-tutorial";
+import { ForceEndBattle } from "../../../game-actions/force-end-battle";
+import { GameProps } from "../../../game-props";
+import { CasualMatch } from "../../../in-progress/casual-match";
+import { PrivateMatchGuest } from "../../../in-progress/private-match-guest";
+import { PrivateMatchHost } from "../../../in-progress/private-match-host";
+import { Story } from "../../../in-progress/story";
+import { playTitleBGM } from "../../play-title-bgm";
+import { startEpisodeSelector } from "../../start-episode-selector";
+import { startTitle } from "../../start-title";
+import { switchWaitingDialog } from "../../switch-dialog/switch-waiting-dialog";
 
 /**
  * ストーリーモードバトルを強制終了する

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/index.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/index.ts
@@ -1,97 +1,8 @@
-import { fadeOut, stop } from "../../../../bgm/bgm-operators";
-import { WaitingDialog } from "../../../../dom-dialogs/waiting/waiting-dialog";
-import { batterySystemTutorial } from "../../../episodes/battery-system-tutorial";
 import { ForceEndBattle } from "../../../game-actions/force-end-battle";
 import { GameProps } from "../../../game-props";
-import { CasualMatch } from "../../../in-progress/casual-match";
-import { PrivateMatchGuest } from "../../../in-progress/private-match-guest";
-import { PrivateMatchHost } from "../../../in-progress/private-match-host";
-import { Story } from "../../../in-progress/story";
-import { playTitleBGM } from "../../play-title-bgm";
-import { startEpisodeSelector } from "../../start-episode-selector";
-import { startTitle } from "../../start-title";
-import { switchWaitingDialog } from "../../switch-dialog/switch-waiting-dialog";
-
-/**
- * ストーリーモードバトルを強制終了する
- * @param props ゲームプロパティ
- * @returns 処理が完了したら発火するPromise
- */
-async function forceEndStoryBattle(
-  props: Readonly<GameProps & { inProgress: Story }>,
-) {
-  props.domFloaters.hiddenPostBattle();
-
-  const selectedEpisodeId =
-    props.inProgress.story.type === "PlayingEpisode"
-      ? props.inProgress.story.episode.id
-      : batterySystemTutorial.id;
-  await Promise.all([
-    (async () => {
-      props.domFloaters.hiddenPostBattle();
-      await startEpisodeSelector(props, selectedEpisodeId);
-    })(),
-    (async () => {
-      await props.bgm.do(fadeOut);
-      await props.bgm.do(stop);
-    })(),
-  ]);
-
-  playTitleBGM(props);
-}
-
-/**
- * ネットバトルを強制終了する
- * @param props ゲームプロパティ
- * @returns 処理が完了したら発火するPromise
- */
-async function forceEndNetBattle(
-  props: Readonly<
-    GameProps & {
-      inProgress: CasualMatch | PrivateMatchHost | PrivateMatchGuest;
-    }
-  >,
-) {
-  props.domFloaters.hiddenPostBattle();
-
-  const dialog = new WaitingDialog("通信中......");
-  switchWaitingDialog(props, dialog);
-  await props.api.disconnectWebsocket();
-  props.domDialogBinder.hidden();
-  await Promise.all([
-    (async () => {
-      await props.fader.fadeOut();
-      await startTitle(props);
-    })(),
-    (async () => {
-      await props.bgm.do(fadeOut);
-      await props.bgm.do(stop);
-    })(),
-  ]);
-  await props.fader.fadeIn();
-  playTitleBGM(props);
-}
-
-/**
- * 汎用的なバトル強制終了
- * @param props ゲームプロパティ
- * @returns 処理が完了したら発火するPromise
- */
-async function forceEndBattle(props: Readonly<GameProps>) {
-  props.domFloaters.hiddenPostBattle();
-  await Promise.all([
-    (async () => {
-      await props.fader.fadeOut();
-      await startTitle(props);
-    })(),
-    (async () => {
-      await props.bgm.do(fadeOut);
-      await props.bgm.do(stop);
-    })(),
-  ]);
-  await props.fader.fadeIn();
-  playTitleBGM(props);
-}
+import { forceEndBattle } from "./force-end-battle";
+import { forceEndNetBattle } from "./force-end-net-battle";
+import { forceEndStoryBattle } from "./force-end-story-battle";
 
 /** onForceEndBattleオプション */
 type ForceEndBattleOptions = {
@@ -110,7 +21,6 @@ type ForceEndBattleOptions = {
 export async function onForceEndBattle(options: ForceEndBattleOptions) {
   const { props } = options;
   const { inProgress } = props;
-
   switch (inProgress.type) {
     case "CasualMatch":
     case "PrivateMatchHost":


### PR DESCRIPTION
This pull request refactors the `onForceEndBattle` functionality by breaking it down into separate modules to improve code maintainability and readability. The key changes include moving specific battle-ending functions to their respective files and updating the main `onForceEndBattle` function to utilize these new modules.

Refactoring of `onForceEndBattle` functionality:

* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts`](diffhunk://#diff-35e699951e2e7f0dc834f31e15de20156e29b722559f6f14d87eb818bf0e8e33R1-R25): Created a new module for the generic battle force-end logic, which includes hiding post-battle elements, fading out, stopping background music, and starting the title screen.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts`](diffhunk://#diff-b9c8c2d511c62329555ec9b7eacc78507be7bc78f7971b52fbab37d052ff0429R1-R41): Created a new module for the network battle force-end logic, including disconnecting the websocket and handling the waiting dialog.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts`](diffhunk://#diff-2abb3f075d4f4a79dc2add09151ac889f22161133a819094c1e0add2c40186b2R1-R34): Created a new module for the story mode battle force-end logic, which involves selecting the appropriate episode and stopping background music.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/index.ts`](diffhunk://#diff-f3ebfc38742bd38dd828586f2384658dfedd7f901297a2d552f8d5f83bec70d5R1-R40): Updated the main `onForceEndBattle` function to utilize the newly created modules for different battle types, ensuring proper handling of each scenario.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle.ts`](diffhunk://#diff-08be3fcb59cf83bf9880a307b19ce37de0b46b47fd060c8b649d5b3eca633674L1-L130): Removed the original implementation of `onForceEndBattle` and its related functions, as they have been moved to separate modules.