### PR TITLE
waitFinishAnimationに強制停止を追加した

### DIFF
--- a/src/js/dom/wait-finish-animation.ts
+++ b/src/js/dom/wait-finish-animation.ts
@@ -11,6 +11,7 @@ export function waitFinishAnimation(
   options?: Partial<SignalContainer>,
 ): Promise<void> {
   let onAbort: (() => void) | null = null;
+  let onFinish: (() => void) | null = null;
   const signal = options?.signal;
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
@@ -24,12 +25,14 @@ export function waitFinishAnimation(
     };
     signal?.addEventListener("abort", onAbort);
 
-    animation.onfinish = () => {
-      resolve();
-    };
+    onFinish = () => resolve();
+    animation.addEventListener("finish", onFinish);
   }).finally(() => {
     if (signal && onAbort) {
       signal.removeEventListener("abort", onAbort);
+    }
+    if (onFinish) {
+      animation.removeEventListener("finish", onFinish);
     }
   });
 }

--- a/src/js/dom/wait-finish-animation.ts
+++ b/src/js/dom/wait-finish-animation.ts
@@ -1,12 +1,35 @@
+import { SignalContainer } from "../abort-controller/signal-container";
+
 /**
  * アニメーションが完了するまで待機する
  * @param animation アニメーション
+ * @param options オプション
  * @returns アニメーションPromise
  */
-export function waitFinishAnimation(animation: Animation): Promise<void> {
-  return new Promise((resolve) => {
+export function waitFinishAnimation(
+  animation: Animation,
+  options?: Partial<SignalContainer>,
+): Promise<void> {
+  let onAbort: (() => void) | null = null;
+  const signal = options?.signal;
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    onAbort = () => {
+      animation.pause();
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", onAbort);
+
     animation.onfinish = () => {
       resolve();
     };
+  }).finally(() => {
+    if (signal && onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
   });
 }


### PR DESCRIPTION
This pull request introduces an enhancement to the `waitFinishAnimation` function in `src/js/dom/wait-finish-animation.ts`. The main change is the addition of an optional `options` parameter that includes a `signal` for aborting the animation. This allows the animation to be paused and the promise to be rejected if an abort signal is received.

Key changes include:

* Added an import statement for `SignalContainer` from `../abort-controller/signal-container`.
* Modified the `waitFinishAnimation` function to accept an optional `options` parameter of type `Partial<SignalContainer>`.
* Implemented logic to handle the abort signal, pausing the animation and rejecting the promise if the signal is aborted.
* Added cleanup logic to remove the abort event listener once the promise is resolved or rejected.