### PR TITLE
ポストバトルボタンを非表示にした場合、ボトムアップアニメを強制終了するようにした

### DIFF
--- a/src/js/dom-floaters/post-battle/index.ts
+++ b/src/js/dom-floaters/post-battle/index.ts
@@ -2,8 +2,7 @@ import { Observable } from "rxjs";
 
 import { PostBattle } from "../../game/post-battle";
 import { createPostBattleFloaterProps } from "./procedures/create-post-battle-floater-props";
-import { destructor } from "./procedures/destructor";
-import { hide } from "./procedures/hide";
+import { hidden } from "./procedures/hidden";
 import { show } from "./procedures/show";
 import { PostBattleFloaterProps } from "./props";
 import { ShowParams } from "./show-params";
@@ -19,13 +18,6 @@ export class PostBattleFloater {
    */
   constructor() {
     this.#props = createPostBattleFloaterProps();
-  }
-
-  /**
-   * デストラクタ相当の処理
-   */
-  destructor(): void {
-    destructor(this.#props);
   }
 
   /**
@@ -49,8 +41,7 @@ export class PostBattleFloater {
    * フローターを非表示にする
    */
   hidden(): void {
-    hide(this.#props);
-    destructor(this.#props);
+    hidden(this.#props);
   }
 
   /**

--- a/src/js/dom-floaters/post-battle/index.ts
+++ b/src/js/dom-floaters/post-battle/index.ts
@@ -2,7 +2,7 @@ import { Observable } from "rxjs";
 
 import { PostBattle } from "../../game/post-battle";
 import { createPostBattleFloaterProps } from "./procedures/create-post-battle-floater-props";
-import { hidden } from "./procedures/hidden";
+import { hide } from "./procedures/hide";
 import { show } from "./procedures/show";
 import { PostBattleFloaterProps } from "./props";
 import { ShowParams } from "./show-params";
@@ -40,8 +40,8 @@ export class PostBattleFloater {
   /**
    * フローターを非表示にする
    */
-  hidden(): void {
-    hidden(this.#props);
+  hide(): void {
+    hide(this.#props);
   }
 
   /**

--- a/src/js/dom-floaters/post-battle/procedures/bottom-up.ts
+++ b/src/js/dom-floaters/post-battle/procedures/bottom-up.ts
@@ -9,19 +9,9 @@ import { PostBattleFloaterProps } from "../props";
 export async function bottomUp(props: PostBattleFloaterProps): Promise<void> {
   props.root.style.display = "flex";
   const animation = props.root.animate(
-    [
-      {
-        transform: "translateY(100%)",
-      },
-      {
-        transform: "translateY(0)",
-      },
-    ],
-    {
-      duration: 400,
-      fill: "forwards",
-      easing: "ease",
-    },
+    [{ transform: "translateY(100%)" }, { transform: "translateY(0)" }],
+    { duration: 400, fill: "forwards", easing: "ease" },
   );
-  await waitFinishAnimation(animation);
+  const { signal } = props.abortController;
+  await waitFinishAnimation(animation, { signal });
 }

--- a/src/js/dom-floaters/post-battle/procedures/create-post-battle-floater-props.ts
+++ b/src/js/dom-floaters/post-battle/procedures/create-post-battle-floater-props.ts
@@ -16,6 +16,7 @@ export function createPostBattleFloaterProps(): PostBattleFloaterProps {
     root,
     exclusive: new Exclusive(),
     selectionComplete: new Subject(),
+    abortController: new AbortController(),
     unsubscribers: [],
   };
 }

--- a/src/js/dom-floaters/post-battle/procedures/hidden.ts
+++ b/src/js/dom-floaters/post-battle/procedures/hidden.ts
@@ -4,10 +4,12 @@ import { PostBattleFloaterProps } from "../props";
  * フローターを非表示にする
  * @param props プロパティ
  */
-export function hidden(props: Readonly<PostBattleFloaterProps>): void {
+export function hidden(props: PostBattleFloaterProps): void {
   props.unsubscribers.forEach((v) => {
     v.unsubscribe();
   });
   props.root.innerHTML = "";
+
   props.abortController.abort();
+  props.abortController = new AbortController();
 }

--- a/src/js/dom-floaters/post-battle/procedures/hidden.ts
+++ b/src/js/dom-floaters/post-battle/procedures/hidden.ts
@@ -1,12 +1,13 @@
 import { PostBattleFloaterProps } from "../props";
 
 /**
- * デストラクタ相当の処理
+ * フローターを非表示にする
  * @param props プロパティ
  */
-export function destructor(props: PostBattleFloaterProps): void {
+export function hidden(props: Readonly<PostBattleFloaterProps>): void {
   props.unsubscribers.forEach((v) => {
     v.unsubscribe();
   });
   props.root.innerHTML = "";
+  props.abortController.abort();
 }

--- a/src/js/dom-floaters/post-battle/procedures/hide.ts
+++ b/src/js/dom-floaters/post-battle/procedures/hide.ts
@@ -1,9 +1,0 @@
-import { PostBattleFloaterProps } from "../props";
-
-/**
- * フローターを非表示にする
- * @param props プロパティ
- */
-export function hide(props: PostBattleFloaterProps): void {
-  props.root.style.display = "none";
-}

--- a/src/js/dom-floaters/post-battle/procedures/hide.ts
+++ b/src/js/dom-floaters/post-battle/procedures/hide.ts
@@ -4,7 +4,7 @@ import { PostBattleFloaterProps } from "../props";
  * フローターを非表示にする
  * @param props プロパティ
  */
-export function hidden(props: PostBattleFloaterProps): void {
+export function hide(props: PostBattleFloaterProps): void {
   props.unsubscribers.forEach((v) => {
     v.unsubscribe();
   });

--- a/src/js/dom-floaters/post-battle/procedures/show.ts
+++ b/src/js/dom-floaters/post-battle/procedures/show.ts
@@ -11,7 +11,7 @@ import { bottomUp } from "./bottom-up";
  */
 export async function show(
   props: PostBattleFloaterProps,
-  params: ShowParams,
+  params: Readonly<ShowParams>,
 ): Promise<void> {
   const actionButtons = params.buttons.map((buttonConfig) =>
     createActionButton({ ...params, props, buttonConfig }),
@@ -20,7 +20,5 @@ export async function show(
     props.root.appendChild(v.button);
   });
   props.unsubscribers = actionButtons.map((v) => v.unsubscriber);
-
-  props.abortController = new AbortController();
   await bottomUp(props);
 }

--- a/src/js/dom-floaters/post-battle/procedures/show.ts
+++ b/src/js/dom-floaters/post-battle/procedures/show.ts
@@ -13,14 +13,14 @@ export async function show(
   props: PostBattleFloaterProps,
   params: ShowParams,
 ): Promise<void> {
-  await props.exclusive.execute(async () => {
-    const actionButtons = params.buttons.map((buttonConfig) =>
-      createActionButton({ ...params, props, buttonConfig }),
-    );
-    actionButtons.forEach((v) => {
-      props.root.appendChild(v.button);
-    });
-    props.unsubscribers = actionButtons.map((v) => v.unsubscriber);
-    await bottomUp(props);
+  const actionButtons = params.buttons.map((buttonConfig) =>
+    createActionButton({ ...params, props, buttonConfig }),
+  );
+  actionButtons.forEach((v) => {
+    props.root.appendChild(v.button);
   });
+  props.unsubscribers = actionButtons.map((v) => v.unsubscriber);
+
+  props.abortController = new AbortController();
+  await bottomUp(props);
 }

--- a/src/js/dom-floaters/post-battle/props.ts
+++ b/src/js/dom-floaters/post-battle/props.ts
@@ -5,7 +5,7 @@ import { Exclusive } from "../../exclusive/exclusive";
 import { PostBattle } from "../../game/post-battle";
 
 /** PostBattleFloaterのプロパティ */
-export type PostBattleFloaterProps =  AbortControllerContainer & {
+export type PostBattleFloaterProps = AbortControllerContainer & {
   /** ルートHTML要素 */
   readonly root: HTMLElement;
   /** 排他制御 */

--- a/src/js/dom-floaters/post-battle/props.ts
+++ b/src/js/dom-floaters/post-battle/props.ts
@@ -1,10 +1,11 @@
 import { Subject, Unsubscribable } from "rxjs";
 
+import { AbortControllerContainer } from "../../abort-controller/abort-controller-container";
 import { Exclusive } from "../../exclusive/exclusive";
 import { PostBattle } from "../../game/post-battle";
 
 /** PostBattleFloaterのプロパティ */
-export type PostBattleFloaterProps = {
+export type PostBattleFloaterProps =  AbortControllerContainer & {
   /** ルートHTML要素 */
   readonly root: HTMLElement;
   /** 排他制御 */

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
@@ -9,7 +9,7 @@ import { startTitle } from "../../start-title";
  * @returns 処理が完了したら発火するPromise
  */
 export async function forceEndBattle(props: Readonly<GameProps>) {
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
@@ -20,7 +20,7 @@ export async function forceEndNetBattle(
     }
   >,
 ) {
-  props.postBattle.hidden();
+  props.postBattle.hide();
 
   const dialog = new WaitingDialog("通信中......");
   switchWaitingDialog(props, dialog);

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
@@ -13,7 +13,7 @@ import { startEpisodeSelector } from "../../start-episode-selector";
 export async function forceEndStoryBattle(
   props: Readonly<GameProps & { inProgress: Story }>,
 ) {
-  props.postBattle.hidden();
+  props.postBattle.hide();
 
   const selectedEpisodeId =
     props.inProgress.story.type === "PlayingEpisode"

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
@@ -21,7 +21,6 @@ export async function forceEndStoryBattle(
       : batterySystemTutorial.id;
   await Promise.all([
     (async () => {
-      props.postBattle.hidden();
       await startEpisodeSelector(props, selectedEpisodeId);
     })(),
     (async () => {

--- a/src/js/game/game-procedure/on-game-action/on-force-retry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-retry.ts
@@ -24,7 +24,7 @@ async function forceRetryNPCBattle(
   const stage = getCurrentNPCStage(state) ?? DefaultStage;
   const level = getNPCStageLevel(state);
   const player = state.player;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startNPCBattleStage(props, player, stage, level);
 }
 
@@ -45,7 +45,7 @@ async function forceRetryStoryBattle(props: GameProps & { inProgress: Story }) {
         return batterySystemTutorial;
     }
   })();
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startEpisode(props, episode);
 }
 

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-ending.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-ending.ts
@@ -21,7 +21,7 @@ type Options = {
  */
 export async function gotoEnding(options: Options): Promise<InProgress> {
   const { props } = options;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await props.fader.fadeOut();
   const scene = new NPCEnding(props);
   switchNpcEnding(props, scene);

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-episode-select.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-episode-select.ts
@@ -46,7 +46,7 @@ export async function gotoEpisodeSelect(options: Options): Promise<InProgress> {
 
   const { story } = inProgress;
   const initialEpisodeId = getInitialEpisodeId(story);
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startEpisodeSelector(props, initialEpisodeId);
   playTitleBGM(props);
   return { type: "Story", story: { type: "EpisodeSelect" } };

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-next-episode.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-next-episode.ts
@@ -13,6 +13,6 @@ export async function gotoNextEpisode(
   >,
 ): Promise<void> {
   const playingEpisode = props.inProgress.story;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startEpisode(props, playingEpisode.nextEpisode);
 }

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-npc-battle-stage.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-npc-battle-stage.ts
@@ -20,6 +20,6 @@ export async function gotoNPCBattleStage(
   const stage = getCurrentNPCStage(state) ?? DefaultStage;
   const level = getNPCStageLevel(state);
   const player = state.player;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startNPCBattleStage(props, player, stage, level);
 }

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-title.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-title.ts
@@ -20,7 +20,7 @@ type Options = {
  */
 export async function gotoTitle(options: Options): Promise<InProgress> {
   const { props } = options;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/retry-episode.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/retry-episode.ts
@@ -13,6 +13,6 @@ export async function retryEpisode(
   >,
 ): Promise<void> {
   const playingEpisode = props.inProgress.story;
-  props.postBattle.hidden();
+  props.postBattle.hide();
   await startEpisode(props, playingEpisode.episode);
 }

--- a/stories/post-battle.stories.ts
+++ b/stories/post-battle.stories.ts
@@ -60,7 +60,7 @@ export const showHidden: StoryFn = domStub((params) => {
   (async () => {
     await floater.show({ ...params, buttons: PostNPCBattleWinButtons });
     await waitTime(3000);
-    floater.hidden();
+    floater.hide();
   })();
 
   return floater.getRootHTMLElement();


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling of post-battle floaters in the codebase. The primary changes involve refactoring methods, updating properties, and improving the animation handling.

Refactoring and method updates:

* [`src/js/dom-floaters/post-battle/index.ts`](diffhunk://#diff-efee3577083acfc0b41c2e776b8407ac50b5c4da75860b61000553a51aa7cc80L5-R5): Replaced the `destructor` method with a `hidden` method and updated related imports and calls accordingly. [[1]](diffhunk://#diff-efee3577083acfc0b41c2e776b8407ac50b5c4da75860b61000553a51aa7cc80L5-R5) [[2]](diffhunk://#diff-efee3577083acfc0b41c2e776b8407ac50b5c4da75860b61000553a51aa7cc80L24-L30) [[3]](diffhunk://#diff-efee3577083acfc0b41c2e776b8407ac50b5c4da75860b61000553a51aa7cc80L52-R44)
* [`src/js/dom-floaters/post-battle/procedures/hidden.ts`](diffhunk://#diff-a0b71ac1cc9921174e883696ea2bea005559820413dc9d81c6efb83fc3a7ad6fL4-R14): Renamed from `destructor.ts` and updated to include aborting the `AbortController`.
* [`src/js/dom-floaters/post-battle/procedures/hide.ts`](diffhunk://#diff-f56b9d355d628b6a9522ba624d9dae3623200f693a3973bed7fc22058eff07d6L1-L9): Removed the `hide` method as it is now redundant.

Property updates:

* [`src/js/dom-floaters/post-battle/procedures/create-post-battle-floater-props.ts`](diffhunk://#diff-33ea16d5e863ec07b846e0b24c031194c3ce66cb8433397ad881ad0c33fb903aR19): Added `AbortController` to the properties created for post-battle floaters.
* [`src/js/dom-floaters/post-battle/props.ts`](diffhunk://#diff-260dfa30f2ea1638660a8c4083e77de0024e9024896de90927897ba6b0e7ff87R3-R8): Updated `PostBattleFloaterProps` type to include `AbortControllerContainer`.

Animation handling improvements:

* [`src/js/dom-floaters/post-battle/procedures/bottom-up.ts`](diffhunk://#diff-26f779251ca21578252bc4d04c42eb0d6963ef8517551faf240fccadd2c1b01bL12-R16): Simplified the animation definition and added support for aborting animations using `AbortController`.

Minor adjustments:

* [`src/js/dom-floaters/post-battle/procedures/show.ts`](diffhunk://#diff-00c3913ac22863d31557503c925710d2c7ec93cfb4725748ec72fa11974f3036L14-L16): Made `ShowParams` read-only and removed redundant execution block. [[1]](diffhunk://#diff-00c3913ac22863d31557503c925710d2c7ec93cfb4725748ec72fa11974f3036L14-L16) [[2]](diffhunk://#diff-00c3913ac22863d31557503c925710d2c7ec93cfb4725748ec72fa11974f3036L25)
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts`](diffhunk://#diff-2abb3f075d4f4a79dc2add09151ac889f22161133a819094c1e0add2c40186b2L24): Removed redundant call to `hidden` method.