### PR TITLE
グランドーザのノックバックを調整した

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
@@ -1,4 +1,5 @@
 import { Animate } from "../../../../animation/animate";
+import { delay } from "../../../../animation/delay";
 import { onStart } from "../../../../animation/on-start";
 import { tween } from "../../../../animation/tween";
 import { GranDozerAnimationProps } from "./animation-props";
@@ -16,12 +17,14 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
       se.play(sounds.motor);
     }),
   )
-    .chain(tween(model.animation, (t) => t.to({ frame: 0 }, 300)))
+    .chain(tween(model.animation, (t) => t.to({ frame: 0 }, 200)))
     .chain(
       tween(model.animation, (t) =>
-        t.to({ frame: 0 }, 0).onStart(() => {
-          model.animation.type = "STAND";
-        }),
+        t
+          .onStart(() => {
+            model.animation.type = "STAND";
+          })
+          .to({ frame: 0 }, 0),
       ),
     )
     .chain(
@@ -33,19 +36,18 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
           .to({ frame: 0 }, 0),
       ),
     )
-    .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 300)))
+    .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 200)))
+    .chain(delay(100))
     .chain(
       tween(model.animation, (t) =>
         t
           .onStart(() => {
             se.play(sounds.motor);
           })
-          .to({ frame: 0 }, 300),
+          .to({ frame: 0 }, 200)
+          .onComplete(() => {
+            model.animation.type = "STAND";
+          }),
       ),
-    )
-    .chain(
-      onStart(() => {
-        model.animation.type = "STAND";
-      }),
     );
 }

--- a/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
@@ -1,6 +1,5 @@
 import { Animate } from "../../../../animation/animate";
 import { delay } from "../../../../animation/delay";
-import { onStart } from "../../../../animation/on-start";
 import { tween } from "../../../../animation/tween";
 import { GranDozerAnimationProps } from "./animation-props";
 


### PR DESCRIPTION
This pull request includes changes to the `knock-back-to-stand` animation for the `GranDozer` game object. The modifications focus on adjusting animation timing and adding a delay to improve the animation sequence.

Improvements to animation timing and sequence:

* [`src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts`](diffhunk://#diff-7ee5ca7152924724f2010eb8a855bec7626731acbef1b1b39b0f333f850f1197R2): Imported the `delay` function to introduce a pause in the animation sequence.
* [`src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts`](diffhunk://#diff-7ee5ca7152924724f2010eb8a855bec7626731acbef1b1b39b0f333f850f1197L19-R27): Adjusted the duration of the `tween` animations from 300ms to 200ms for smoother transitions.
* [`src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts`](diffhunk://#diff-7ee5ca7152924724f2010eb8a855bec7626731acbef1b1b39b0f333f850f1197L36-R51): Added a 100ms delay between specific animation frames to enhance the visual effect.