### PR TITLE
無駄なコードを削除した

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
@@ -21,15 +21,6 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
       tween(model.animation, (t) =>
         t
           .onStart(() => {
-            model.animation.type = "STAND";
-          })
-          .to({ frame: 0 }, 0),
-      ),
-    )
-    .chain(
-      tween(model.animation, (t) =>
-        t
-          .onStart(() => {
             model.animation.type = "FRONT_STEP";
           })
           .to({ frame: 0 }, 0),


### PR DESCRIPTION
This pull request includes a small change to the `knockBackToStand` function in the `src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts` file. The change simplifies the animation sequence by removing an unnecessary tween chain that sets the animation type to "STAND". 

* [`src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts`](diffhunk://#diff-7ee5ca7152924724f2010eb8a855bec7626731acbef1b1b39b0f333f850f1197L20-L28): Removed redundant tween chain that set the animation type to "STAND".