### PR TITLE
グランドーザのノックバックを調整

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
@@ -27,7 +27,7 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
       ),
     )
     .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 250)))
-    .chain(delay(200))
+    .chain(delay(300))
     .chain(
       tween(model.animation, (t) =>
         t


### PR DESCRIPTION
This pull request includes a minor adjustment to the `knockBackToStand` animation in the `GranDozer` game object. The delay in the animation sequence has been increased to improve the visual timing.

* [`src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts`](diffhunk://#diff-7ee5ca7152924724f2010eb8a855bec7626731acbef1b1b39b0f333f850f1197L30-R30): Increased the delay in the animation sequence from 200ms to 300ms to enhance the visual effect.