### PR TITLE
グランドーザのダウンモーションを調整

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/down.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/down.ts
@@ -22,7 +22,7 @@ export function down(props: GranDozerAnimationProps): Animate {
         t.to({ x: "+70" }, 500).easing(Easing.Quadratic.Out),
       ),
     )
-    .chain(delay(100))
+    .chain(delay(400))
     .chain(tween(model, (t) => t.to({ animation: { frame: 0 } }, 250)))
     .chain(
       tween(model.animation, (t) =>
@@ -31,6 +31,5 @@ export function down(props: GranDozerAnimationProps): Animate {
         }),
       ),
     )
-    .chain(delay(200))
     .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 250)));
 }


### PR DESCRIPTION
This pull request includes changes to the `down` function in the `src/js/game-object/armdozer/gran-dozer/animation/down.ts` file to adjust the animation timing.

Changes to animation timing:

* Increased the delay from 100ms to 400ms after the initial tween.
* Removed an additional 200ms delay before the final tween.