### PR TITLE
ポストバトルのストーリーブックを修正した

### DIFF
--- a/stories/post-battle.stories.ts
+++ b/stories/post-battle.stories.ts
@@ -1,6 +1,7 @@
 import { StoryFn } from "@storybook/html";
 
 import { PostBattleFloater } from "../src/js/dom-floaters/post-battle";
+import type { PostBattleButtonConfig } from "../src/js/dom-floaters/post-battle/post-battle-button-config";
 import {
   PostNetworkBattleButtons,
   PostNPCBattleComplete,
@@ -14,45 +15,40 @@ export default {
   title: "post-battle",
 };
 
+/**
+ * ポストバトルのストーリーを生成する
+ * @param buttons ボタン設定
+ * @returns ストーリー
+ */
+const postBattleStory = (buttons: PostBattleButtonConfig[]) =>
+  domStub((params) => {
+    const floater = new PostBattleFloater();
+    floater.show({ ...params, buttons });
+    floater.selectionCompleteNotifier().subscribe((postBattle) => {
+      console.log(postBattle);
+    });
+    return floater.getRootHTMLElement();
+  });
+
 /** NPCバトル勝利 */
-export const postNPCBattleWin: StoryFn = domStub((params) => {
-  const floater = new PostBattleFloater();
-  floater.show({ ...params, buttons: PostNPCBattleWinButtons });
-  floater.selectionCompleteNotifier().subscribe((postBattle) => {
-    console.log(postBattle);
-  });
-  return floater.getRootHTMLElement();
-});
+export const postNPCBattleWin: StoryFn = postBattleStory(
+  PostNPCBattleWinButtons,
+);
 
-/** NPCバトル敗北 */
-export const postNPCBattleLose: StoryFn = domStub((params) => {
-  const floater = new PostBattleFloater();
-  floater.show({ ...params, buttons: PostNPCBattleLoseButtons });
-  floater.selectionCompleteNotifier().subscribe((postBattle) => {
-    console.log(postBattle);
-  });
-  return floater.getRootHTMLElement();
-});
+/** NPCバトル敗北 PostNPCBattleLoseButtons */
+export const postNPCBattleLose: StoryFn = postBattleStory(
+  PostNPCBattleLoseButtons,
+);
 
-/** NPCバトル完全クリア */
-export const postNPCBattleComplete: StoryFn = domStub((params) => {
-  const floater = new PostBattleFloater();
-  floater.show({ ...params, buttons: PostNPCBattleComplete });
-  floater.selectionCompleteNotifier().subscribe((postBattle) => {
-    console.log(postBattle);
-  });
-  return floater.getRootHTMLElement();
-});
+/** NPCバトル完全クリア  */
+export const postNPCBattleComplete: StoryFn = postBattleStory(
+  PostNPCBattleComplete,
+);
 
 /** ネット対戦終了 */
-export const postNetworkBattle: StoryFn = domStub((params) => {
-  const floater = new PostBattleFloater();
-  floater.show({ ...params, buttons: PostNetworkBattleButtons });
-  floater.selectionCompleteNotifier().subscribe((postBattle) => {
-    console.log(postBattle);
-  });
-  return floater.getRootHTMLElement();
-});
+export const postNetworkBattle: StoryFn = postBattleStory(
+  PostNetworkBattleButtons,
+);
 
 /** 表示、非表示の繰り返し */
 export const showHidden: StoryFn = domStub((params) => {

--- a/stories/post-battle.stories.ts
+++ b/stories/post-battle.stories.ts
@@ -3,6 +3,9 @@ import { StoryFn } from "@storybook/html";
 import { PostBattleFloater } from "../src/js/dom-floaters/post-battle";
 import type { PostBattleButtonConfig } from "../src/js/dom-floaters/post-battle/post-battle-button-config";
 import {
+  PostEpisodeButtons,
+  PostEpisodeLoseButtons,
+  PostEpisodeWinButtons,
   PostNetworkBattleButtons,
   PostNPCBattleComplete,
   PostNPCBattleLoseButtons,
@@ -49,6 +52,15 @@ export const postNPCBattleComplete: StoryFn = postBattleStory(
 export const postNetworkBattle: StoryFn = postBattleStory(
   PostNetworkBattleButtons,
 );
+
+/** エピソード終了 */
+export const postEpisode: StoryFn = postBattleStory(PostEpisodeButtons);
+
+/** エピソード終了（プレイヤーの勝利） */
+export const postEpisodeWin: StoryFn = postBattleStory(PostEpisodeWinButtons);
+
+/** エピソード終了（プレイヤーの敗北） */
+export const postEpisodeLose: StoryFn = postBattleStory(PostEpisodeLoseButtons);
 
 /** 表示、非表示の繰り返し */
 export const showHidden: StoryFn = domStub((params) => {


### PR DESCRIPTION
This pull request includes changes to the `stories/post-battle.stories.ts` file to refactor and simplify the story generation for post-battle scenarios. The most important changes include the introduction of a new helper function to reduce code duplication and the addition of new story exports for various post-battle outcomes.

Refactoring and code simplification:

* Added a new helper function `postBattleStory` to generate post-battle stories, reducing code duplication.
* Replaced individual story functions for NPC battle win, NPC battle lose, NPC battle complete, and network battle with calls to the new `postBattleStory` function.

New story exports:

* Added new story exports for episode end scenarios: `postEpisode`, `postEpisodeWin`, and `postEpisodeLose`.

Type import:

* Imported `PostBattleButtonConfig` type to ensure type safety for the new `postBattleStory` function.