### PR TITLE
グランドーザのダウンモーションを調整

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/down.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/down.ts
@@ -22,7 +22,7 @@ export function down(props: GranDozerAnimationProps): Animate {
         t.to({ x: "+70" }, 500).easing(Easing.Quadratic.Out),
       ),
     )
-    .chain(delay(400))
+    .chain(delay(100))
     .chain(tween(model, (t) => t.to({ animation: { frame: 0 } }, 250)))
     .chain(
       tween(model.animation, (t) =>
@@ -31,5 +31,6 @@ export function down(props: GranDozerAnimationProps): Animate {
         }),
       ),
     )
+    .chain(delay(10))
     .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 250)));
 }


### PR DESCRIPTION
This pull request includes changes to the `down` function in the `src/js/game-object/armdozer/gran-dozer/animation/down.ts` file to adjust the animation timing.

Changes to animation timing:

* [`src/js/game-object/armdozer/gran-dozer/animation/down.ts`](diffhunk://#diff-ff92089f3bf83be082e3b26b58ab898b3ef8de42d1e64250bc315959ab432473L25-R25): Reduced the delay from 400ms to 100ms in the animation chain.
* [`src/js/game-object/armdozer/gran-dozer/animation/down.ts`](diffhunk://#diff-ff92089f3bf83be082e3b26b58ab898b3ef8de42d1e64250bc315959ab432473R34): Added an additional 10ms delay in the animation chain.