### PR TITLE
ポストバトルのボタンスタイルを調整

### DIFF
--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -24,7 +24,7 @@
 
 .post-battle__sub-action {
   border: var(--sub-button-border);
-  font-size: calc(var(--responsive-font-size) * 1);
+  font-size: calc(var(--responsive-font-size) * 1.2);
   background-color: var(--sub-button-background-color);
   box-shadow: var(--sub-button-box-shadow);
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/css/post-battle.css` file. The change increases the font size of the `.post-battle__sub-action` class to improve readability.

* [`src/css/post-battle.css`](diffhunk://#diff-ba4fb0e241254ac041d7594257de9aeb7d85ca96f39024e9570140b702e61203L27-R27): Modified the `font-size` property of the `.post-battle__sub-action` class from `calc(var(--responsive-font-size) * 1)` to `calc(var(--responsive-font-size) * 1.2)` to enhance readability.