### PR TITLE
ポストバトルのメインボタンフォントサイズを小さくした

### DIFF
--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -31,7 +31,7 @@
 
 .post-battle__main-action {
   border: 3px solid #00b0e6;
-  font-size: calc(var(--responsive-font-size) * 1.5);
+  font-size: calc(var(--responsive-font-size) * 1.4);
   font-weight: bold;
   background-color: var(--button-background-color);
   box-shadow: var(--sub-button-box-shadow);


### PR DESCRIPTION
This pull request includes a small change to the `src/css/post-battle.css` file. The change adjusts the font size calculation for the `.post-battle__main-action` class to be slightly smaller.

* [`src/css/post-battle.css`](diffhunk://#diff-ba4fb0e241254ac041d7594257de9aeb7d85ca96f39024e9570140b702e61203L34-R34): Changed the font size calculation from `calc(var(--responsive-font-size) * 1.5)` to `calc(var(--responsive-font-size) * 1.4)`.