### PR TITLE
ポストバトルのボタン幅を調整した

### DIFF
--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -16,7 +16,7 @@
 
 .post-battle__main-action,
 .post-battle__sub-action {
-  min-width: 30vw;
+  min-width: 32vw;
   min-height: calc(var(--responsive-font-size) * 4.5);
   border-radius: var(--button-border-radius);
   color: var(--button-font-color);

--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -16,7 +16,7 @@
 
 .post-battle__main-action,
 .post-battle__sub-action {
-  min-width: 37.5vw;
+  min-width: 30vw;
   min-height: calc(var(--responsive-font-size) * 4.5);
   border-radius: var(--button-border-radius);
   color: var(--button-font-color);


### PR DESCRIPTION
This pull request includes a change to the `src/css/post-battle.css` file to adjust the minimum width of certain elements.

Styling adjustments:

* [`src/css/post-battle.css`](diffhunk://#diff-ba4fb0e241254ac041d7594257de9aeb7d85ca96f39024e9570140b702e61203L19-R19): Reduced the `min-width` of `.post-battle__main-action` and `.post-battle__sub-action` from `37.5vw` to `32vw` to improve layout responsiveness.