### PR TITLE
グランドーザの携帯用画像を25%縮小するようにした

### DIFF
--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -52,17 +52,23 @@ async function resizeWebp(origin: string, scale: number): Promise<void> {
     "build/production/resources/**/mobile/armdozer/wing-dozer/burst-up.webp",
     "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
     "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
+    "build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp",
   ];
+  const granDozerWebpImages =
+    "build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp";
   const pngModelTextures =
     "build/production/resources/**/mobile/**/model/**/*.png";
 
-  const [webpImagePaths, pngModelTexturePaths] = await Promise.all([
-    glob(webpImages, { ignore: ignoreWebpImages }),
-    glob(pngModelTextures),
-  ]);
+  const [webpImagePaths, granDozerImagePaths, pngModelTexturePaths] =
+    await Promise.all([
+      glob(webpImages, { ignore: ignoreWebpImages }),
+      glob(granDozerWebpImages),
+      glob(pngModelTextures),
+    ]);
   await Promise.all([
-    ...webpImagePaths.map((v) => resizeWebp(v, 0.5)),
-    ...pngModelTexturePaths.map((v) => resizePng(v, 0.25)),
+    ...webpImagePaths.map((p) => resizeWebp(p, 0.5)),
+    ...granDozerImagePaths.map((p) => resizeWebp(p, 0.25)),
+    ...pngModelTexturePaths.map((p) => resizePng(p, 0.25)),
   ]);
 
   console.log("complete scale down mobile images");

--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -90,8 +90,8 @@ const getWebpPaths = () =>
   console.log("start scale down mobile images");
 
   const [
-    granDozerWebpPathsFor25percent,
-    granDozerWebpPathsFor50percent,
+    granDozer25percentWebpPaths,
+    granDozer50percentWebpPaths,
     pngModelTexturePaths,
     webpPaths,
   ] = await Promise.all([
@@ -101,8 +101,8 @@ const getWebpPaths = () =>
     getWebpPaths(),
   ]);
   await Promise.all([
-    ...granDozerWebpPathsFor25percent.map((p) => resizeWebp(p, 0.25)),
-    ...granDozerWebpPathsFor50percent.map((p) => resizeWebp(p, 0.5)),
+    ...granDozer25percentWebpPaths.map((p) => resizeWebp(p, 0.25)),
+    ...granDozer50percentWebpPaths.map((p) => resizeWebp(p, 0.5)),
     ...pngModelTexturePaths.map((p) => resizePng(p, 0.25)),
     ...webpPaths.map((p) => resizeWebp(p, 0.5)),
   ]);

--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -34,40 +34,61 @@ async function resizeWebp(origin: string, scale: number): Promise<void> {
 }
 
 /**
+ * グランドーザの画像パスを取得する
+ * @return グランドーザの画像パス
+ */
+const getGranDozerWebpPaths = () =>
+  glob("build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp", {
+    ignore: [
+      "build/production/resources/**/mobile/armdozer/gran-dozer/bust-shot.webp",
+      "build/production/resources/**/mobile/armdozer/gran-dozer/player-select.webp",
+    ],
+  });
+
+/**
+ * pngモデルテクスチャのパスを取得する
+ * @return pngモデルテクスチャのパス
+ */
+const pngPngModelTexturrPaths = () =>
+  glob("build/production/resources/**/mobile/**/model/**/*.png");
+
+/**
+ * webp画像のパスを取得する
+ * @return webp画像のパス
+ */
+const getWebpPaths = () =>
+  glob("build/production/resources/**/mobile/**/*.webp", {
+    ignore: [
+      "build/production/resources/**/mobile/default-user-icon.webp",
+      "build/production/resources/**/mobile/armdozer/shin-braver/cutin-down.webp",
+      "build/production/resources/**/mobile/armdozer/shin-braver/cutin-up.webp",
+      "build/production/resources/**/mobile/armdozer/neo-landozer/cutin-down.webp",
+      "build/production/resources/**/mobile/armdozer/neo-landozer/cutin-up.webp",
+      "build/production/resources/**/mobile/armdozer/lightning-dozer/cutin-down.webp",
+      "build/production/resources/**/mobile/armdozer/lightning-dozer/cutin-up.webp",
+      "build/production/resources/**/mobile/armdozer/wing-dozer/burst-down.webp",
+      "build/production/resources/**/mobile/armdozer/wing-dozer/burst-up.webp",
+      "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
+      "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
+      "build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp",
+    ],
+  });
+
+/**
  * モバイル用画像をスケールダウンする
  */
 (async () => {
   console.log("start scale down mobile images");
 
-  const webpImages = "build/production/resources/**/mobile/**/*.webp";
-  const ignoreWebpImages = [
-    "build/production/resources/**/mobile/default-user-icon.webp",
-    "build/production/resources/**/mobile/armdozer/shin-braver/cutin-down.webp",
-    "build/production/resources/**/mobile/armdozer/shin-braver/cutin-up.webp",
-    "build/production/resources/**/mobile/armdozer/neo-landozer/cutin-down.webp",
-    "build/production/resources/**/mobile/armdozer/neo-landozer/cutin-up.webp",
-    "build/production/resources/**/mobile/armdozer/lightning-dozer/cutin-down.webp",
-    "build/production/resources/**/mobile/armdozer/lightning-dozer/cutin-up.webp",
-    "build/production/resources/**/mobile/armdozer/wing-dozer/burst-down.webp",
-    "build/production/resources/**/mobile/armdozer/wing-dozer/burst-up.webp",
-    "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
-    "build/production/resources/**/mobile/armdozer/genesis-braver/cutin-burst-up.webp",
-    "build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp",
-  ];
-  const granDozerWebpImages =
-    "build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp";
-  const pngModelTextures =
-    "build/production/resources/**/mobile/**/model/**/*.png";
-
-  const [webpImagePaths, granDozerImagePaths, pngModelTexturePaths] =
+  const [granDozerWebpPaths, pngModelTexturePaths, webpPaths] =
     await Promise.all([
-      glob(webpImages, { ignore: ignoreWebpImages }),
-      glob(granDozerWebpImages),
-      glob(pngModelTextures),
+      getGranDozerWebpPaths(),
+      pngPngModelTexturrPaths(),
+      getWebpPaths(),
     ]);
   await Promise.all([
-    ...webpImagePaths.map((p) => resizeWebp(p, 0.5)),
-    ...granDozerImagePaths.map((p) => resizeWebp(p, 0.25)),
+    ...webpPaths.map((p) => resizeWebp(p, 0.5)),
+    ...granDozerWebpPaths.map((p) => resizeWebp(p, 0.25)),
     ...pngModelTexturePaths.map((p) => resizePng(p, 0.25)),
   ]);
 

--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -58,7 +58,7 @@ const getGranDozerWebpPathsFor50Percent = () =>
  * pngモデルテクスチャのパスを取得する
  * @return pngモデルテクスチャのパス
  */
-const pngPngModelTexturrPaths = () =>
+const getPngModelTexturePaths = () =>
   glob("build/production/resources/**/mobile/**/model/**/*.png");
 
 /**
@@ -97,7 +97,7 @@ const getWebpPaths = () =>
   ] = await Promise.all([
     getGranDozerWebpPathsFor25Percent(),
     getGranDozerWebpPathsFor50Percent(),
-    pngPngModelTexturrPaths(),
+    getPngModelTexturePaths(),
     getWebpPaths(),
   ]);
   await Promise.all([

--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -34,16 +34,25 @@ async function resizeWebp(origin: string, scale: number): Promise<void> {
 }
 
 /**
- * グランドーザの画像パスを取得する
+ * 25%縮小するグランドーザ画像パスを取得する
  * @return グランドーザの画像パス
  */
-const getGranDozerWebpPaths = () =>
+const getGranDozerWebpPathsFor25Percent = () =>
   glob("build/production/resources/**/mobile/armdozer/gran-dozer/**/*.webp", {
     ignore: [
       "build/production/resources/**/mobile/armdozer/gran-dozer/bust-shot.webp",
       "build/production/resources/**/mobile/armdozer/gran-dozer/player-select.webp",
     ],
   });
+
+/**
+ * 50%縮小するグランドーザの画像パスを取得する
+ * @return グランドーザの画像パス
+ */
+const getGranDozerWebpPathsFor50Percent = () =>
+  glob(
+    "build/production/resources/**/mobile/armdozer/gran-dozer/**/player-select.webp",
+  );
 
 /**
  * pngモデルテクスチャのパスを取得する
@@ -80,16 +89,22 @@ const getWebpPaths = () =>
 (async () => {
   console.log("start scale down mobile images");
 
-  const [granDozerWebpPaths, pngModelTexturePaths, webpPaths] =
-    await Promise.all([
-      getGranDozerWebpPaths(),
-      pngPngModelTexturrPaths(),
-      getWebpPaths(),
-    ]);
+  const [
+    granDozerWebpPathsFor25percent,
+    granDozerWebpPathsFor50percent,
+    pngModelTexturePaths,
+    webpPaths,
+  ] = await Promise.all([
+    getGranDozerWebpPathsFor25Percent(),
+    getGranDozerWebpPathsFor50Percent(),
+    pngPngModelTexturrPaths(),
+    getWebpPaths(),
+  ]);
   await Promise.all([
-    ...webpPaths.map((p) => resizeWebp(p, 0.5)),
-    ...granDozerWebpPaths.map((p) => resizeWebp(p, 0.25)),
+    ...granDozerWebpPathsFor25percent.map((p) => resizeWebp(p, 0.25)),
+    ...granDozerWebpPathsFor50percent.map((p) => resizeWebp(p, 0.5)),
     ...pngModelTexturePaths.map((p) => resizePng(p, 0.25)),
+    ...webpPaths.map((p) => resizeWebp(p, 0.5)),
   ]);
 
   console.log("complete scale down mobile images");


### PR DESCRIPTION
This pull request includes changes to the `scale-down-mobile-images.ts` file to improve the handling of image paths and the scaling process for mobile images. The main changes include the addition of functions to get specific image paths and the restructuring of the main scaling function to use these new functions.

Improvements to image path handling:

* Added `getGranDozerWebpPathsFor25Percent` function to get paths for 25% scaled-down GranDozer images.
* Added `getGranDozerWebpPathsFor50Percent` function to get paths for 50% scaled-down GranDozer images.
* Added `pngPngModelTexturrPaths` function to get paths for PNG model textures.
* Added `getWebpPaths` function to get paths for webp images with specified ignore patterns.

Restructuring of the scaling function:

* Modified the main scaling function to use the newly added functions for retrieving image paths and to handle the scaling process accordingly.