### PR TITLE
バトルシミュレーターでダイアログ外を押しても閉じれない不具合を修正

### DIFF
--- a/src/css/battle-simulator.css
+++ b/src/css/battle-simulator.css
@@ -153,6 +153,7 @@
   grid-area: player;
   width: var(--player-area-width);
   height: var(--player-area-height);
+  overflow: hidden;
 }
 
 .battle-simulator__player-armdozer--shin-braver,
@@ -173,6 +174,7 @@
   grid-area: enemy;
   width: var(--player-area-width);
   height: var(--player-area-height);
+  overflow: hidden;
 }
 
 .battle-simulator__enemy-armdozer--shin-braver,

--- a/src/css/battle-simulator.css
+++ b/src/css/battle-simulator.css
@@ -221,8 +221,8 @@
 
 .battle-simulator__player-armdozer--gran-dozer,
 .battle-simulator__enemy-armdozer--gran-dozer {
-  width: calc(var(--responsive-font-size) * 28);
-  height: calc(var(--responsive-font-size) * 28);
+  width: calc(var(--responsive-font-size) * 26);
+  height: calc(var(--responsive-font-size) * 26);
 }
 
 .battle-simulator__player-battery-value,


### PR DESCRIPTION
This pull request includes several updates to the `src/css/battle-simulator.css` file to enhance the layout and appearance of the battle simulator. The most important changes include adding overflow properties to player and enemy areas and adjusting the dimensions of specific armdozer elements.

Layout and appearance improvements:

* Added `overflow: hidden` property to the player area to prevent content overflow. (`src/css/battle-simulator.css`, [src/css/battle-simulator.cssR156](diffhunk://#diff-03a45c64654eb08c073f99ba3f54188a6c4d60649aefb491bf64c6515558cfcbR156))
* Added `overflow: hidden` property to the enemy area to prevent content overflow. (`src/css/battle-simulator.css`, [src/css/battle-simulator.cssR177](diffhunk://#diff-03a45c64654eb08c073f99ba3f54188a6c4d60649aefb491bf64c6515558cfcbR177))
* Adjusted the width and height of `gran-dozer` armdozer elements to improve responsiveness. (`src/css/battle-simulator.css`, [src/css/battle-simulator.cssL222-R225](diffhunk://#diff-03a45c64654eb08c073f99ba3f54188a6c4d60649aefb491bf64c6515558cfcbL222-R225))