### PR TITLE
ゲームオブジェクトアクション専用のインタフェースを追加

### DIFF
--- a/src/js/game-object/action/game-object-action-container.ts
+++ b/src/js/game-object/action/game-object-action-container.ts
@@ -1,0 +1,9 @@
+import { Observable } from "rxjs";
+
+import { GameObjectAction } from "./game-object-action";
+
+/** ゲームオブジェクトアクションコンテナ */
+export type GameObjectActionContainer = {
+  /** ゲームオブジェクトアクション */
+  gameObjectAction: Observable<GameObjectAction>;
+};

--- a/stories/stub/td-game-object-stub.ts
+++ b/stories/stub/td-game-object-stub.ts
@@ -8,6 +8,7 @@ import {
   GameObjectAction,
   gameObjectStream,
 } from "../../src/js/game-object/action/game-object-action";
+import { GameObjectActionContainer } from "../../src/js/game-object/action/game-object-action-container";
 import { TDCamera } from "../../src/js/game-object/camera/td";
 import { Renderer } from "../../src/js/render";
 import { OverlapEvent } from "../../src/js/render/overlap-event/overlap-event";
@@ -23,9 +24,8 @@ import { StorybookResourceRoot } from "../storybook-resource-root";
 
 /** Object3D生成関数パラメータ */
 type Object3DCreatorParams = ResourcesContainer &
-  SEPlayerContainer & {
-    /** ゲームオブジェクトアクション */
-    gameObjectAction: Observable<GameObjectAction>;
+  SEPlayerContainer &
+  GameObjectActionContainer & {
     /** カメラ */
     camera: TDCamera;
   };


### PR DESCRIPTION
This pull request includes changes to the `src/js/game-object/action/game-object-action-container.ts` and `stories/stub/td-game-object-stub.ts` files to introduce a new type for handling game object actions and to update the relevant imports and type definitions accordingly.

Introduction of `GameObjectActionContainer` type:

* [`src/js/game-object/action/game-object-action-container.ts`](diffhunk://#diff-b9f0059e4c2da51ec9d8f9e5d6d2f6a1d996c278a1bd881e9ff7ae82bcea0334R1-R9): Added a new type `GameObjectActionContainer` to encapsulate the `gameObjectAction` as an `Observable<GameObjectAction>`.

Updates to imports and type definitions:

* [`stories/stub/td-game-object-stub.ts`](diffhunk://#diff-861580af3f924c2fc57666c354e93556446b05b339a94d7a54883e77fdf9470dR11): Updated the imports to include `GameObjectActionContainer` and modified the `Object3DCreatorParams` type to use `GameObjectActionContainer` instead of directly defining `gameObjectAction`. [[1]](diffhunk://#diff-861580af3f924c2fc57666c354e93556446b05b339a94d7a54883e77fdf9470dR11) [[2]](diffhunk://#diff-861580af3f924c2fc57666c354e93556446b05b339a94d7a54883e77fdf9470dL26-R28)