### PR TITLE
DOMシーンへの切り替えでアニメーションをAbortするようにした

### DIFF
--- a/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
+++ b/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
@@ -1,29 +1,33 @@
 import { Unsubscribable } from "rxjs";
 
+import { createAbortError } from "../../../abort-controller/abort-error";
+import { AbortManagerContainer } from "../../../abort-controller/abort-manager-container";
 import { DOMScene } from "../../../dom-scenes/dom-scene";
 import { DOMSceneBinder } from "../../../dom-scenes/dom-scene-binder";
 import { TDSceneBinder } from "../../../td-scenes/td-scene-binder";
 
-/** シーン切り替えパラメータ */
-type Params = {
+/** シーン切り替えオプション */
+type Options = Readonly<AbortManagerContainer> & {
   /** DOMシーンバインダ */
-  domSceneBinder: DOMSceneBinder;
+  readonly domSceneBinder: DOMSceneBinder;
   /** 3Dシーンバインダ */
-  tdSceneBinder: TDSceneBinder;
+  readonly tdSceneBinder: TDSceneBinder;
   /** 切り替え先のDOMシーン */
-  scene: DOMScene;
+  readonly scene: DOMScene;
   /** バインドするシーンに関連するアンサブスクライバ */
-  unsubscribers: Unsubscribable[];
+  readonly unsubscribers: Unsubscribable[];
 };
 
 /**
  * DOMシーンに切り替える
  * 切り替え前に3Dシーンを表示していた場合、そのシーンを破棄する
  * 本関数はこのフォルダ以外では呼び出してはならない
- * @param params シーン切り替えパラメータ
+ * @param options シーン切り替えオプション
  */
-export const switchDOMScene = (params: Params): void => {
-  const { domSceneBinder, tdSceneBinder, scene, unsubscribers } = params;
+export const switchDOMScene = (options: Options): void => {
+  const { abort, domSceneBinder, tdSceneBinder, scene, unsubscribers } =
+    options;
+  abort.getAbortController().abort(createAbortError("scene switch"));
   if (tdSceneBinder.isSceneBound()) {
     tdSceneBinder.dispose();
   }

--- a/src/js/td-scenes/battle/index.ts
+++ b/src/js/td-scenes/battle/index.ts
@@ -1,6 +1,5 @@
 import { Observable, Unsubscribable } from "rxjs";
 
-import { createAbortError } from "../../abort-controller/abort-error";
 import { TDScene } from "../td-scene";
 import { bindEventListeners } from "./procedure/bind-event-listeners";
 import {
@@ -44,10 +43,6 @@ export class BattleScene implements TDScene {
 
   /** @override */
   destructor(): void {
-    // TODO ゲーム全体で見て適切な場所でabortするようにする
-    this.#props.abort
-      .getAbortController()
-      .abort(createAbortError("battle scene is destructed"));
     this.#props.view.destructor();
     this.#unSubscribers.forEach((v) => {
       v.unsubscribe();


### PR DESCRIPTION
This pull request includes updates to the `switch-scene` and `battle` modules to improve scene management and error handling. The most important changes include the introduction of a new abort error mechanism and the modification of scene switch parameters to use read-only properties.

Improvements to scene management:

* [`src/js/game/game-procedure/switch-scene/switch-dom-scene.ts`](diffhunk://#diff-5c36c52cd54b36f9ab1adf35af5f22d5659cfb0c5922b2220e00078f55a6bdd5R3-R30): Introduced `createAbortError` and `AbortManagerContainer` for better error handling during scene switches. Changed the `Params` type to `Options` and made all properties read-only.

Codebase simplification:

* [`src/js/td-scenes/battle/index.ts`](diffhunk://#diff-41632d6cf575a3a82bf62542f87765cb0174567005a3801cbdd68e1e5485cf4aL3): Removed the abort error creation in the `destructor` method of the `BattleScene` class to streamline the destruction process. [[1]](diffhunk://#diff-41632d6cf575a3a82bf62542f87765cb0174567005a3801cbdd68e1e5485cf4aL3) [[2]](diffhunk://#diff-41632d6cf575a3a82bf62542f87765cb0174567005a3801cbdd68e1e5485cf4aL47-L50)