### PR TITLE
ポストバトルボタンの非表示制御を改良した

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts
@@ -9,7 +9,6 @@ import { startTitle } from "../../start-title";
  * @returns 処理が完了したら発火するPromise
  */
 export async function forceEndBattle(props: Readonly<GameProps>) {
-  props.postBattle.hide();
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
@@ -20,8 +20,6 @@ export async function forceEndNetBattle(
     }
   >,
 ) {
-  props.postBattle.hide();
-
   const dialog = new WaitingDialog("通信中......");
   switchWaitingDialog(props, dialog);
   await props.api.disconnectWebsocket();

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts
@@ -13,8 +13,6 @@ import { startEpisodeSelector } from "../../start-episode-selector";
 export async function forceEndStoryBattle(
   props: Readonly<GameProps & { inProgress: Story }>,
 ) {
-  props.postBattle.hide();
-
   const selectedEpisodeId =
     props.inProgress.story.type === "PlayingEpisode"
       ? props.inProgress.story.episode.id

--- a/src/js/game/game-procedure/on-game-action/on-force-retry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-retry.ts
@@ -24,7 +24,6 @@ async function forceRetryNPCBattle(
   const stage = getCurrentNPCStage(state) ?? DefaultStage;
   const level = getNPCStageLevel(state);
   const player = state.player;
-  props.postBattle.hide();
   await startNPCBattleStage(props, player, stage, level);
 }
 
@@ -45,7 +44,6 @@ async function forceRetryStoryBattle(props: GameProps & { inProgress: Story }) {
         return batterySystemTutorial;
     }
   })();
-  props.postBattle.hide();
   await startEpisode(props, episode);
 }
 

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-ending.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-ending.ts
@@ -21,7 +21,6 @@ type Options = {
  */
 export async function gotoEnding(options: Options): Promise<InProgress> {
   const { props } = options;
-  props.postBattle.hide();
   await props.fader.fadeOut();
   const scene = new NPCEnding(props);
   switchNpcEnding(props, scene);

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-episode-select.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-episode-select.ts
@@ -46,7 +46,6 @@ export async function gotoEpisodeSelect(options: Options): Promise<InProgress> {
 
   const { story } = inProgress;
   const initialEpisodeId = getInitialEpisodeId(story);
-  props.postBattle.hide();
   await startEpisodeSelector(props, initialEpisodeId);
   playTitleBGM(props);
   return { type: "Story", story: { type: "EpisodeSelect" } };

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-next-episode.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-next-episode.ts
@@ -13,6 +13,5 @@ export async function gotoNextEpisode(
   >,
 ): Promise<void> {
   const playingEpisode = props.inProgress.story;
-  props.postBattle.hide();
   await startEpisode(props, playingEpisode.nextEpisode);
 }

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-npc-battle-stage.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-npc-battle-stage.ts
@@ -20,6 +20,5 @@ export async function gotoNPCBattleStage(
   const stage = getCurrentNPCStage(state) ?? DefaultStage;
   const level = getNPCStageLevel(state);
   const player = state.player;
-  props.postBattle.hide();
   await startNPCBattleStage(props, player, stage, level);
 }

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/goto-title.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/goto-title.ts
@@ -20,7 +20,6 @@ type Options = {
  */
 export async function gotoTitle(options: Options): Promise<InProgress> {
   const { props } = options;
-  props.postBattle.hide();
   await Promise.all([
     (async () => {
       await props.fader.fadeOut();

--- a/src/js/game/game-procedure/on-game-action/on-post-battle/retry-episode.ts
+++ b/src/js/game/game-procedure/on-game-action/on-post-battle/retry-episode.ts
@@ -13,6 +13,5 @@ export async function retryEpisode(
   >,
 ): Promise<void> {
   const playingEpisode = props.inProgress.story;
-  props.postBattle.hide();
   await startEpisode(props, playingEpisode.episode);
 }

--- a/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
+++ b/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
@@ -2,6 +2,7 @@ import { Unsubscribable } from "rxjs";
 
 import { createAbortError } from "../../../abort-controller/abort-error";
 import { AbortManagerContainer } from "../../../abort-controller/abort-manager-container";
+import { PostBattleFloater } from "../../../dom-floaters/post-battle";
 import { DOMScene } from "../../../dom-scenes/dom-scene";
 import { DOMSceneBinder } from "../../../dom-scenes/dom-scene-binder";
 import { TDSceneBinder } from "../../../td-scenes/td-scene-binder";
@@ -14,6 +15,8 @@ type Options = Readonly<AbortManagerContainer> & {
   readonly tdSceneBinder: TDSceneBinder;
   /** 切り替え先のDOMシーン */
   readonly scene: DOMScene;
+  /** ポストバトルフローター */
+  readonly postBattle: PostBattleFloater;
   /** バインドするシーンに関連するアンサブスクライバ */
   readonly unsubscribers: Unsubscribable[];
 };
@@ -25,9 +28,16 @@ type Options = Readonly<AbortManagerContainer> & {
  * @param options シーン切り替えオプション
  */
 export const switchDOMScene = (options: Options): void => {
-  const { abort, domSceneBinder, tdSceneBinder, scene, unsubscribers } =
-    options;
-  abort.getAbortController().abort(createAbortError("scene switch"));
+  const {
+    abort,
+    postBattle,
+    domSceneBinder,
+    tdSceneBinder,
+    scene,
+    unsubscribers,
+  } = options;
+  abort.getAbortController().abort(createAbortError("switch scene"));
+  postBattle.hide();
   if (tdSceneBinder.isSceneBound()) {
     tdSceneBinder.dispose();
   }


### PR DESCRIPTION
This pull request focuses on removing the `postBattle.hide()` method call from various game procedure functions and updating the `switchDOMScene` function to include the `postBattle` option. The changes aim to streamline the game flow by eliminating unnecessary method calls and ensuring consistent handling of the `postBattle` floater.

### Removal of `postBattle.hide()` Method Calls:

* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-battle.ts`](diffhunk://#diff-35e699951e2e7f0dc834f31e15de20156e29b722559f6f14d87eb818bf0e8e33L12): Removed `postBattle.hide()` call from `forceEndBattle` function.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts`](diffhunk://#diff-b9c8c2d511c62329555ec9b7eacc78507be7bc78f7971b52fbab37d052ff0429L23-L24): Removed `postBattle.hide()` call from `forceEndNetBattle` function.
* [`src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-story-battle.ts`](diffhunk://#diff-2abb3f075d4f4a79dc2add09151ac889f22161133a819094c1e0add2c40186b2L16-L17): Removed `postBattle.hide()` call from `forceEndStoryBattle` function.
* [`src/js/game/game-procedure/on-game-action/on-force-retry.ts`](diffhunk://#diff-1ca7489ae1c9ee02cb3736e3c1f36d227689ea7036d58d33c0c8bbe6cb0c0682L27): Removed `postBattle.hide()` call from `forceRetryNPCBattle` and `forceRetryStoryBattle` functions. [[1]](diffhunk://#diff-1ca7489ae1c9ee02cb3736e3c1f36d227689ea7036d58d33c0c8bbe6cb0c0682L27) [[2]](diffhunk://#diff-1ca7489ae1c9ee02cb3736e3c1f36d227689ea7036d58d33c0c8bbe6cb0c0682L48)
* [`src/js/game/game-procedure/on-game-action/on-post-battle/goto-ending.ts`](diffhunk://#diff-99369308212d057bb584457a842c4b1b7658df41787b88ede2e312b271ad826dL24): Removed `postBattle.hide()` call from `gotoEnding` function.
* [`src/js/game/game-procedure/on-game-action/on-post-battle/goto-episode-select.ts`](diffhunk://#diff-9ac7f580363efb1d2150af4bbc9b314db00c410df9d9c87b8b853a3a8b5d2748L49): Removed `postBattle.hide()` call from `gotoEpisodeSelect` function.
* [`src/js/game/game-procedure/on-game-action/on-post-battle/goto-next-episode.ts`](diffhunk://#diff-4731cb61e3bbc3ed0ba6dfef60094a30482e2b8d8e39e05c26f90dff68a6df4aL16): Removed `postBattle.hide()` call from `gotoNextEpisode` function.
* [`src/js/game/game-procedure/on-game-action/on-post-battle/goto-npc-battle-stage.ts`](diffhunk://#diff-9a86e6863a812d20f7dd1029ecc07547feeba37c5280b9dcb2ded5a7dc6f879dL23): Removed `postBattle.hide()` call from `gotoNPCBattleStage` function.
* [`src/js/game/game-procedure/on-game-action/on-post-battle/goto-title.ts`](diffhunk://#diff-0b3dfdcc1b9c477bc3a3598583903cc042784da8f5fad96cc6ad430959835f6bL23): Removed `postBattle.hide()` call from `gotoTitle` function.
* [`src/js/game/game-procedure/on-game-action/on-post-battle/retry-episode.ts`](diffhunk://#diff-11df8a24f2b33ecfd9c7f34be9d95dea914dcc704fece47696f1be29a88728cbL16): Removed `postBattle.hide()` call from `retryEpisode` function.

### Update to `switchDOMScene` Function:

* [`src/js/game/game-procedure/switch-scene/switch-dom-scene.ts`](diffhunk://#diff-5c36c52cd54b36f9ab1adf35af5f22d5659cfb0c5922b2220e00078f55a6bdd5R5): Added `postBattle` property to `Options` type and included `postBattle.hide()` call in `switchDOMScene` function. [[1]](diffhunk://#diff-5c36c52cd54b36f9ab1adf35af5f22d5659cfb0c5922b2220e00078f55a6bdd5R5) [[2]](diffhunk://#diff-5c36c52cd54b36f9ab1adf35af5f22d5659cfb0c5922b2220e00078f55a6bdd5R18-R19) [[3]](diffhunk://#diff-5c36c52cd54b36f9ab1adf35af5f22d5659cfb0c5922b2220e00078f55a6bdd5L28-R40)