### PR TITLE
スマートフォンでグランドーザカットインの解像度が大幅に下がる不具合を修正

### DIFF
--- a/scale-down-mobile-images.ts
+++ b/scale-down-mobile-images.ts
@@ -42,6 +42,8 @@ const getGranDozerWebpPathsFor25Percent = () =>
     ignore: [
       "build/production/resources/**/mobile/armdozer/gran-dozer/bust-shot.webp",
       "build/production/resources/**/mobile/armdozer/gran-dozer/player-select.webp",
+      "build/production/resources/**/mobile/armdozer/gran-dozer/cutin-burst-down.webp",
+      "build/production/resources/**/mobile/armdozer/gran-dozer/cutin-burst-up.webp",
     ],
   });
 


### PR DESCRIPTION
This pull request includes a small change to the `scale-down-mobile-images.ts` file. The change adds two new image paths to the list of ignored files in the `getGranDozerWebpPathsFor25Percent` function.

* [`scale-down-mobile-images.ts`](diffhunk://#diff-df4b10db6089982935ea978242456e508b4f438c30aa11da69ef1ac52dc235faR45-R46): Added "cutin-burst-down.webp" and "cutin-burst-up.webp" to the ignore list in the `getGranDozerWebpPathsFor25Percent` function.