### PR TITLE
グランドーザバーストアニメーションを調整した

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/burst.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/burst.ts
@@ -17,7 +17,7 @@ export function burst(props: GranDozerAnimationProps) {
     }),
   )
     .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 300)))
-    .chain(delay(300))
+    .chain(delay(400))
     .chain(
       tween(model, (t) =>
         t

--- a/src/js/game-object/cut-in/gran-dozer/animation/show.ts
+++ b/src/js/game-object/cut-in/gran-dozer/animation/show.ts
@@ -19,7 +19,7 @@ export function show(props: GranDozerCutInAnimationProps): Animate {
       }),
     )
       .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 300)))
-      .chain(delay(300))
+      .chain(delay(400))
       .chain(
         tween(model, (t) =>
           t

--- a/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
+++ b/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
@@ -12,7 +12,7 @@ import { LightningShotModel } from "../model/lightning-shot-model";
 import { LightningShotView } from "./lightning-shot-view";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 400;
+const MESH_SIZE = 280;
 
 /** プレイヤーの電撃ショットビュー */
 export class PlayerLightningShotView implements LightningShotView {
@@ -51,7 +51,7 @@ export class PlayerLightningShotView implements LightningShotView {
     this.#mesh.opacity(model.opacity);
     this.#mesh.animate(model.animation.frame);
     const target = this.#mesh.getObject3D();
-    target.position.x = ARMDOZER_EFFECT_STANDARD_X - MESH_SIZE / 2 - 80;
+    target.position.x = ARMDOZER_EFFECT_STANDARD_X - MESH_SIZE / 2 - 85;
     target.position.y = ARMDOZER_EFFECT_STANDARD_Y + 40;
     target.position.z = ARMDOZER_EFFECT_STANDARD_Z + 1;
   }

--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -48,14 +48,16 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
     param.hudObjects.rearmostFader.opacity(0.6, 500),
     param.attackerArmdozerTD.sprite().endActive(),
   )
-    .chain(delay(800))
+    .chain(delay(1000))
     .chain(
       all(
-        param.hudObjects.rearmostFader.opacity(0, 300),
+        toInitial(param.tdCamera, 200),
+        param.hudObjects.rearmostFader.opacity(0, 200),
         param.burstArmdozerHUD.cutIn.hidden(),
+        param.burstArmdozerTD.lightningShot.shot(),
+        param.otherArmdozerTD.sprite().knockBack(),
       ),
     )
-    .chain(param.burstArmdozerTD.lightningShot.shot())
     .chain(delay(300))
     .chain(
       all(
@@ -67,8 +69,8 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
     )
     .chain(
       all(
-        toInitial(param.tdCamera, 500),
         param.burstArmdozerTD.granDozer.burstToStand(),
+        param.otherArmdozerTD.sprite().knockBackToStand(),
         param.tdObjects.skyBrightness.brightness(1, 500),
         param.tdObjects.illumination.intensity(1, 500),
       ),


### PR DESCRIPTION
This pull request includes several changes to the animation timings and visual properties in the `src/js` directory. The most important changes include adjustments to delay timings, mesh size, and object positions.

### Animation Timing Adjustments:
* [`src/js/game-object/armdozer/gran-dozer/animation/burst.ts`](diffhunk://#diff-d01972a67edf004123c6edeca8cd51179a5190e89da501ca4390c8fae16af0f5L20-R20): Increased the delay from 300ms to 400ms in the `burst` function.
* [`src/js/game-object/cut-in/gran-dozer/animation/show.ts`](diffhunk://#diff-b5db41468144fd03ba32815a026297edd3f6d6c52432a6bdb342ca6d5d7a2a42L22-R22): Increased the delay from 300ms to 400ms in the `show` function.
* [`src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts`](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL51-L58): Increased the delay from 800ms to 1000ms in the `ineffective` function and added new animations for `lightningShot` and `knockBack`. [[1]](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL51-L58) [[2]](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL70-R73)

### Visual Properties Adjustments:
* [`src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts`](diffhunk://#diff-6e1da5c23caaea04f256e76f3d68d7be04dc9af9b55ad5d8c70fb9cad6e73f5cL15-R15): Reduced the `MESH_SIZE` from 400 to 280 and adjusted the `x` position of the target object. [[1]](diffhunk://#diff-6e1da5c23caaea04f256e76f3d68d7be04dc9af9b55ad5d8c70fb9cad6e73f5cL15-R15) [[2]](diffhunk://#diff-6e1da5c23caaea04f256e76f3d68d7be04dc9af9b55ad5d8c70fb9cad6e73f5cL54-R54)