### PR TITLE
グランドーザのバーストアニメーションを調整した

### DIFF
--- a/src/js/dom-scenes/player-select/dedicated-pilot.ts
+++ b/src/js/dom-scenes/player-select/dedicated-pilot.ts
@@ -10,7 +10,6 @@ export function getDedicatedPilot(armdozerId: ArmdozerId): PilotId {
     case ArmdozerIds.SHIN_BRAVER:
       return PilotIds.SHINYA;
     case ArmdozerIds.NEO_LANDOZER:
-    case ArmdozerIds.GRAN_DOZER:
       return PilotIds.GAI;
     case ArmdozerIds.LIGHTNING_DOZER:
       return PilotIds.RAITO;
@@ -18,6 +17,8 @@ export function getDedicatedPilot(armdozerId: ArmdozerId): PilotId {
       return PilotIds.TSUBASA;
     case ArmdozerIds.GENESIS_BRAVER:
       return PilotIds.YUUYA;
+    case ArmdozerIds.GRAN_DOZER:
+      return PilotIds.RAITO;
     default:
       return PilotIds.SHINYA;
   }

--- a/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
+++ b/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
@@ -12,7 +12,7 @@ import { LightningShotModel } from "../model/lightning-shot-model";
 import { LightningShotView } from "./lightning-shot-view";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 280;
+const MESH_SIZE = 380;
 
 /** プレイヤーの電撃ショットビュー */
 export class PlayerLightningShotView implements LightningShotView {
@@ -51,7 +51,7 @@ export class PlayerLightningShotView implements LightningShotView {
     this.#mesh.opacity(model.opacity);
     this.#mesh.animate(model.animation.frame);
     const target = this.#mesh.getObject3D();
-    target.position.x = ARMDOZER_EFFECT_STANDARD_X - MESH_SIZE / 2 - 85;
+    target.position.x = ARMDOZER_EFFECT_STANDARD_X - MESH_SIZE / 2 - 10;
     target.position.y = ARMDOZER_EFFECT_STANDARD_Y + 40;
     target.position.z = ARMDOZER_EFFECT_STANDARD_Z + 1;
   }

--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -61,10 +61,13 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
         toInitial(param.tdCamera, 300),
         param.burstArmdozerTD.lightningShot.shot(),
         param.otherArmdozerTD.sprite().knockBack(),
-        param.otherPlayerTD.armdozerEffects.ineffective.show(),
+        param.otherPlayerTD.armdozerEffects.ineffective
+          .show()
+          .chain(delay(800))
+          .chain(param.otherPlayerTD.armdozerEffects.ineffective.hidden()),
       ),
     )
-    .chain(delay(300))
+    .chain(delay(200))
     .chain(
       all(
         param.burstPlayerHUD.gauge.battery(
@@ -76,7 +79,6 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
     .chain(
       all(
         param.burstArmdozerTD.granDozer.burstToStand(),
-        param.otherPlayerTD.armdozerEffects.ineffective.hidden(),
         param.otherArmdozerTD.sprite().knockBackToStand(),
         param.tdObjects.skyBrightness.brightness(1, 500),
         param.tdObjects.illumination.intensity(1, 500),

--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -63,11 +63,11 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
         param.otherArmdozerTD.sprite().knockBack(),
         param.otherPlayerTD.armdozerEffects.ineffective
           .show()
-          .chain(delay(800))
+          .chain(delay(1000))
           .chain(param.otherPlayerTD.armdozerEffects.ineffective.hidden()),
       ),
     )
-    .chain(delay(200))
+    .chain(delay(100))
     .chain(
       all(
         param.burstPlayerHUD.gauge.battery(


### PR DESCRIPTION
This pull request includes several changes to the `PlayerLightningShotView` and `ineffective` function in the game code. The main focus is on adjusting the mesh size and position, as well as refining the animation sequence for the ineffective burst effect.

Changes to `PlayerLightningShotView`:

* Increased the `MESH_SIZE` constant from 280 to 380 in `player-lightning-shot-view.ts` to accommodate a larger mesh size.
* Adjusted the x-position of the target mesh in the `PlayerLightningShotView` class to align with the new mesh size and improve visual positioning.

Changes to `ineffective` function:

* Enhanced the animation sequence by chaining additional effects and adjusting delays to improve the visual flow of the ineffective burst effect in `gran-dozer.ts`. [[1]](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL64-R70) [[2]](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL79)