### PR TITLE
敵グランドーザのバーストカットインの位置がおかしい不具合を修正した

### DIFF
--- a/src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts
+++ b/src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts
@@ -30,7 +30,10 @@ export class PlayerGranDozerCutInView implements GranDozerCutInView {
     this.#group = new THREE.Group();
     this.#meshes = createMeshes(resources);
     this.#meshes.forEach(({ mesh }) => {
-      this.#group.add(mesh.getObject3D());
+      const target = mesh.getObject3D();
+      target.position.x = BASE_PADDING_LEFT;
+      target.position.y = -BASE_PADDING_TOP;
+      this.#group.add(target);
     });
   }
 
@@ -59,8 +62,8 @@ export class PlayerGranDozerCutInView implements GranDozerCutInView {
 
     const scale =
       hudScale(preRender.rendererDOM, preRender.safeAreaInset) * model.scale;
-    this.#group.position.x = model.tracking.x + BASE_PADDING_LEFT * scale;
-    this.#group.position.y = model.tracking.y - BASE_PADDING_TOP * scale;
+    this.#group.position.x = model.tracking.x;
+    this.#group.position.y = model.tracking.y;
     this.#group.position.z = HUD_CUT_IN_Z;
     this.#group.scale.x = scale;
     this.#group.scale.y = scale;


### PR DESCRIPTION
This pull request includes changes to the `PlayerGranDozerCutInView` class in the `player-gran-dozer-cut-in-view.ts` file to adjust the positioning logic for the meshes and the group. The most important changes include modifying the position of individual meshes and updating the group's position calculation.

Positioning adjustments:

* [`src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts`](diffhunk://#diff-dfa53d68a29fb360ddca2ce7330976a3096fd7a43115be06cf7e134307d8b33cL33-R36): Changed the position of individual meshes by setting `target.position.x` to `BASE_PADDING_LEFT` and `target.position.y` to `-BASE_PADDING_TOP` before adding them to the group.
* [`src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts`](diffhunk://#diff-dfa53d68a29fb360ddca2ce7330976a3096fd7a43115be06cf7e134307d8b33cL62-R66): Updated the group's position calculation by removing the addition of `BASE_PADDING_LEFT * scale` and `-BASE_PADDING_TOP * scale` from `model.tracking.x` and `model.tracking.y`, respectively.