### PR TITLE
グランドーザのバーストアニメーションを調整した

### DIFF
--- a/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
+++ b/src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts
@@ -12,7 +12,7 @@ import { LightningShotModel } from "../model/lightning-shot-model";
 import { LightningShotView } from "./lightning-shot-view";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 380;
+const MESH_SIZE = 360;
 
 /** プレイヤーの電撃ショットビュー */
 export class PlayerLightningShotView implements LightningShotView {

--- a/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
+++ b/src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts
@@ -63,10 +63,11 @@ function ineffective(param: GranDozerBurst<Ineffective>): Animate {
         param.otherArmdozerTD.sprite().knockBack(),
         param.otherPlayerTD.armdozerEffects.ineffective
           .show()
-          .chain(delay(600))
+          .chain(delay(800))
           .chain(param.otherPlayerTD.armdozerEffects.ineffective.hidden()),
       ),
     )
+    .chain(delay(100))
     .chain(
       all(
         param.burstPlayerHUD.gauge.battery(


### PR DESCRIPTION
This pull request includes changes to the `src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts` and `src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts` files to adjust mesh size and delay timings for animations. The most important changes are:

### Mesh Size Adjustment:
* [`src/js/game-object/shot/lightning-shot/view/player-lightning-shot-view.ts`](diffhunk://#diff-6e1da5c23caaea04f256e76f3d68d7be04dc9af9b55ad5d8c70fb9cad6e73f5cL15-R15): Reduced the mesh size constant `MESH_SIZE` from 380 to 360.

### Animation Timing Adjustments:
* [`src/js/td-scenes/battle/animation/game-state/burst/gran-dozer.ts`](diffhunk://#diff-5b88a07f49120e9a624798be8072f701499232c64f7ad044413896aabaca3fffL66-R70): Increased the delay in the `ineffective` function from 600ms to 800ms and added an additional 100ms delay in the animation chain.