### PR TITLE
CubeTextureをファイル分割した

### DIFF
--- a/src/js/resource/cube-texture/configs.ts
+++ b/src/js/resource/cube-texture/configs.ts
@@ -1,0 +1,15 @@
+import { CUBE_TEXTURE_IDS } from "./ids";
+import { CubeTextureConfig } from "./resource";
+
+/** キューブテクスチャ設定をまとめたもの */
+export const CUBE_TEXTURE_CONFIGS: CubeTextureConfig[] = [
+  {
+    id: CUBE_TEXTURE_IDS.BlueSky,
+    px: "sky-box/blue-sky/px.webp",
+    nx: "sky-box/blue-sky/nx.webp",
+    py: "sky-box/blue-sky/py.webp",
+    ny: "sky-box/blue-sky/ny.webp",
+    pz: "sky-box/blue-sky/pz.webp",
+    nz: "sky-box/blue-sky/nz.webp",
+  },
+];

--- a/src/js/resource/cube-texture/ids.ts
+++ b/src/js/resource/cube-texture/ids.ts
@@ -1,0 +1,4 @@
+/** キューブテクスチャIDをまとめたもの */
+export const CUBE_TEXTURE_IDS = {
+  BlueSky: "BlueSky",
+};

--- a/src/js/resource/cube-texture/load-cube-texture.ts
+++ b/src/js/resource/cube-texture/load-cube-texture.ts
@@ -1,44 +1,7 @@
 import * as THREE from "three";
 
-import type { ResourceRoot } from "./resource-root";
-
-/** キューブテクスチャID */
-export type CuteTextureId = string;
-
-/** キューブテクスチャ設定 */
-export type CubeTextureConfig = {
-  id: CuteTextureId;
-  px: string;
-  nx: string;
-  py: string;
-  ny: string;
-  pz: string;
-  nz: string;
-};
-
-/** キューブテクスチャリソース */
-export type CubeTextureResource = {
-  id: CuteTextureId;
-  texture: THREE.CubeTexture;
-};
-
-/** キューブテクスチャIDをまとめたもの */
-export const CUBE_TEXTURE_IDS = {
-  BlueSky: "BlueSky",
-};
-
-/** キューブテクスチャ設定をまとめたもの */
-export const CUBE_TEXTURE_CONFIGS: CubeTextureConfig[] = [
-  {
-    id: CUBE_TEXTURE_IDS.BlueSky,
-    px: "sky-box/blue-sky/px.webp",
-    nx: "sky-box/blue-sky/nx.webp",
-    py: "sky-box/blue-sky/py.webp",
-    ny: "sky-box/blue-sky/ny.webp",
-    pz: "sky-box/blue-sky/pz.webp",
-    nz: "sky-box/blue-sky/nz.webp",
-  },
-];
+import type { ResourceRoot } from "../resource-root";
+import { CubeTextureConfig, CubeTextureResource } from "./resource";
 
 /**
  * キューブテクスチャを読み込み

--- a/src/js/resource/cube-texture/resource.ts
+++ b/src/js/resource/cube-texture/resource.ts
@@ -1,0 +1,21 @@
+import * as THREE from "three";
+
+/** キューブテクスチャID */
+export type CuteTextureId = string;
+
+/** キューブテクスチャ設定 */
+export type CubeTextureConfig = {
+  id: CuteTextureId;
+  px: string;
+  nx: string;
+  py: string;
+  ny: string;
+  pz: string;
+  nz: string;
+};
+
+/** キューブテクスチャリソース */
+export type CubeTextureResource = {
+  id: CuteTextureId;
+  texture: THREE.CubeTexture;
+};

--- a/src/js/resource/cube-texture/resource.ts
+++ b/src/js/resource/cube-texture/resource.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 
 /** キューブテクスチャID */
-export type CuteTextureId = string;
+export type CubeTextureId = string;
 
 /** キューブテクスチャ設定 */
 export type CubeTextureConfig = {
-  id: CuteTextureId;
+  id: CubeTextureId;
   px: string;
   nx: string;
   py: string;
@@ -16,6 +16,6 @@ export type CubeTextureConfig = {
 
 /** キューブテクスチャリソース */
 export type CubeTextureResource = {
-  id: CuteTextureId;
+  id: CubeTextureId;
   texture: THREE.CubeTexture;
 };

--- a/src/js/resource/index.ts
+++ b/src/js/resource/index.ts
@@ -1,5 +1,5 @@
 import { CanvasImageResource } from "./canvas-image";
-import { CubeTextureResource } from "./cube-texture";
+import { CubeTextureResource } from "./cube-texture/resource";
 import { GlTFResource } from "./gltf/resource";
 import { Path } from "./path/resource";
 import { ResourceRoot } from "./resource-root";

--- a/src/js/resource/loading/full-resource-configs.ts
+++ b/src/js/resource/loading/full-resource-configs.ts
@@ -1,5 +1,5 @@
 import { CANVAS_IMAGE_CONFIGS } from "../canvas-image";
-import { CUBE_TEXTURE_CONFIGS } from "../cube-texture";
+import { CUBE_TEXTURE_CONFIGS } from "../cube-texture/configs";
 import { GLTF_CONFIGS } from "../gltf/configs";
 import { SOUND_CONFIGS } from "../sound/configs";
 import {

--- a/src/js/resource/loading/resource-loading.ts
+++ b/src/js/resource/loading/resource-loading.ts
@@ -3,8 +3,11 @@ import { Observable, Subject } from "rxjs";
 import type { Resources } from "..";
 import type { CanvasImageConfig, CanvasImageResource } from "../canvas-image";
 import { loadCanvasImage } from "../canvas-image";
-import type { CubeTextureConfig, CubeTextureResource } from "../cube-texture";
-import { loadCubeTexture } from "../cube-texture";
+import { loadCubeTexture } from "../cube-texture/load-cube-texture";
+import {
+  CubeTextureConfig,
+  CubeTextureResource,
+} from "../cube-texture/resource";
 import { loadGlTF } from "../gltf/load-gltf";
 import { GlTFConfig, GlTFResource } from "../gltf/resource";
 import { getAllPaths } from "../path/get-all-paths";

--- a/src/js/td-scenes/battle/view/td/sky-box.ts
+++ b/src/js/td-scenes/battle/view/td/sky-box.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 
 import { Resources } from "../../../../resource";
-import { CUBE_TEXTURE_IDS } from "../../../../resource/cube-texture";
+import { CUBE_TEXTURE_IDS } from "../../../../resource/cube-texture/ids";
 
 /**
  * スカイボックスを生成するヘルパー関数


### PR DESCRIPTION
This pull request refactors the cube texture resource structure by splitting its configuration, IDs, and loading logic into separate files. It also updates all relevant imports to reflect this new structure, improving modularity and maintainability.

### Refactoring of Cube Texture Resources:

* Created `CUBE_TEXTURE_IDS` in a new file `src/js/resource/cube-texture/ids.ts` to manage cube texture IDs separately.
* Moved cube texture configurations to `src/js/resource/cube-texture/configs.ts` and updated the structure to reference `CUBE_TEXTURE_IDS`.
* Extracted type definitions (`CubeTextureConfig`, `CubeTextureResource`, etc.) into a new file `src/js/resource/cube-texture/resource.ts` for better organization.

### File Renaming and Import Updates:

* Renamed `src/js/resource/cube-texture.ts` to `src/js/resource/cube-texture/load-cube-texture.ts` to better reflect its purpose and updated its imports accordingly.
* Updated all imports across the codebase to reflect the new file structure, including changes in `src/js/resource/index.ts`, `src/js/resource/loading/full-resource-configs.ts`, `src/js/resource/loading/resource-loading.ts`, and `src/js/td-scenes/battle/view/td/sky-box.ts`. [[1]](diffhunk://#diff-994de9c9c26503d3d7befbc9570730c972c28fa52761613c0c06e952e8a6ba78L2-R2) [[2]](diffhunk://#diff-a1e4de7c2ae4adf6ea6043c073a75c9c4a40520fa089e055118b585e6367cdd6L2-R2) [[3]](diffhunk://#diff-3625d592a128466ac871776427430bb16b6646fc73a4a60e4aa311c110bc6c37L6-R10) [[4]](diffhunk://#diff-613c0349c7d125293a40271e297b6ea721edd5c574df07e3cb41b6c4f42b24ecL4-R4)