### PR TITLE
updateUntilNowを追加

### DIFF
--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -53,8 +53,10 @@ export type StateUpdateStarted = CustomBattleEventProps &
 export type CustomStateAnimation = CustomBattleEventProps & {
   /** 再生するステート */
   readonly currentState: GameState;
-  /** コマンド入力から最終ステートまでのステート更新履歴 */
+  /** コマンド入力から最終ステートまでの更新履歴 */
   readonly update: GameState[];
+  /** コマンド入力から現在のステートまでの更新履歴 */
+  readonly updateUntilNow: GameState[];
 };
 
 /** 最終ステート系イベントのプロパティ */

--- a/src/js/td-scenes/battle/procedure/play-state-history.ts
+++ b/src/js/td-scenes/battle/procedure/play-state-history.ts
@@ -46,10 +46,12 @@ export async function playStateHistory(
           next &&
           parallelPlayEffects.includes(next.effect.name) &&
           parallelPlayEffects.includes(gameState.effect.name);
+        const updateUntilNow = gameStateHistory.slice(0, index + 1);
         const customStateAnimationProps = {
           ...props,
           currentState: gameState,
           update: gameStateHistory,
+          updateUntilNow,
         };
         const anime = all(
           stateAnimation(props, gameState),


### PR DESCRIPTION
Adds the ability to track the game state history up to the current state.

This allows for more granular control and analysis of the game's progression, particularly useful for animation and debugging purposes.