### PR TITLE
依存ライブラリをアップデートした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.16.22",
+        "@gbraver-burst-network/browser-sdk": "1.16.23",
         "@tweenjs/tween.js": "^25.0.0",
-        "gbraver-burst-core": "1.36.1",
+        "gbraver-burst-core": "1.36.2",
         "handlebars": "^4.7.8",
         "howler": "^2.2.4",
         "jsqr": "^1.4.0",
@@ -26,11 +26,11 @@
         "workbox-precaching": "^7.3.0",
         "workbox-routing": "^7.3.0",
         "workbox-strategies": "^7.3.0",
-        "zod": "^3.24.3"
+        "zod": "^3.24.4"
       },
       "devDependencies": {
-        "@html-eslint/eslint-plugin": "^0.39.0",
-        "@html-eslint/parser": "^0.39.0",
+        "@html-eslint/eslint-plugin": "^0.40.0",
+        "@html-eslint/parser": "^0.40.0",
         "@storybook/addon-backgrounds": "^8.6.12",
         "@storybook/html": "^8.6.12",
         "@storybook/html-webpack5": "^8.6.12",
@@ -47,7 +47,7 @@
         "css-loader": "^7.1.2",
         "dependency-cruiser": "^16.10.1",
         "dotenv": "^16.5.0",
-        "eslint": "^9.25.1",
+        "eslint": "^9.26.0",
         "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "glob": "^11.0.2",
@@ -74,7 +74,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.31.0",
+        "typescript-eslint": "^8.32.0",
         "webpack": "^5.99.7",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.1"
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.79",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.79.tgz",
-      "integrity": "sha512-6dtlzqcRjtfOB41253950Gweu/y4kLDOvaOkoT+MbvfHnqeeUt5uvYTc+spJq0o+Ht63B2MhVVPFhTitffiIGA==",
+      "version": "7.0.80",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.80.tgz",
+      "integrity": "sha512-KJ22bNnlW+mIAYl+2nM3ZTXhM6svAHUnT0Oi1yzGAwDO0wGYiIUEtV4Vx+21iOZrS3RDrJSEtdynQzfD0eQpLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.621.0",
@@ -114,13 +114,13 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.10.tgz",
-      "integrity": "sha512-oEjnBJizI3oTBw5IGQfllFtE/XQYUBFZZJr8Dbrhxt96ZHiFNmxCFIH4Zh3rPAC6lNnS4AR5r4kMt5dLB7g9HQ==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.11.tgz",
+      "integrity": "sha512-Osp264EBrrp6Rp87Df+y7ngv33kriOY2LxQU40lccUfk3CpFN2nrMbIPZ3JGH0n265L1CGJw3XjpeCLmO3s8ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.7.14",
-        "@aws-amplify/api-rest": "4.1.3",
+        "@aws-amplify/api-graphql": "4.7.15",
+        "@aws-amplify/api-rest": "4.1.4",
         "@aws-amplify/data-schema": "^1.7.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.0"
@@ -130,13 +130,13 @@
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.7.14",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.7.14.tgz",
-      "integrity": "sha512-3m93TNOyxBt59DwR8j+mOk5SJ+KAR5/rpGNw3sdmr8u3XhZTp5fQxettnVUZ4oOIph8Bnw+hf/NGZcg3emjDTQ==",
+      "version": "4.7.15",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.7.15.tgz",
+      "integrity": "sha512-6lU3Cw7ExvEHFh2jwEgSIA5ws+KyqahmP00u0++W59Lmcg46Y+TJZ27HUlIZkc/QbOk3/HN9M6YopdRa0LqeCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.1.3",
-        "@aws-amplify/core": "6.11.3",
+        "@aws-amplify/api-rest": "4.1.4",
+        "@aws-amplify/core": "6.11.4",
         "@aws-amplify/data-schema": "^1.7.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.1.3.tgz",
-      "integrity": "sha512-+qmnAGZBhJpMeX+MZGCkWmrPkbyttSuiHI1F/aPMEfW4Y2NDjCn+QKSoqXeTmGHmhkiHitcg/+RWeDaA+qB2dg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.1.4.tgz",
+      "integrity": "sha512-3ajXDy+7XTZriiFR+vqtsnQ5tf4RskkEMpUp++eT+R+pBvudqlAkqe4lB0ABXB1/r1+kXJqDHWEgaXT3DZQZJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.12.3.tgz",
-      "integrity": "sha512-wMmwMwymcmbNKZFiDEbPlko6d+g/BSGlgULC51x8DJClc1y0XqdPISOeCjesxmTQqCqsxLAxakmLMd8iKRMd8Q==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.12.4.tgz",
+      "integrity": "sha512-3qi3dKJUdYVDS3nCO2YeIK4Djj0vzDEjv2ZpfraYNVBUGXj4GnL7wSUm7r1VD3SYqnHgzoAIdW/73P5ormEMfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.11.3.tgz",
-      "integrity": "sha512-NKm04dA2ob7nLEk+vGDVrKVCQkPSOtEVDvcmwItE+QRD291lKl1AMQDucAo3BZaLmfTY7gfIMjyRgHFWsSJ6JA==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.11.4.tgz",
+      "integrity": "sha512-qkLyu3GxmJNH6gk9WwKEkOjQ0uUMyOuYqJgf97M6DV6btfoqBFY0T18wd+JEqjKm8awk4liRObU4b9/FQPuS9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -268,13 +268,13 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.81",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.81.tgz",
-      "integrity": "sha512-sP6wLyDGposa8eCm+vZeLZQ219XEoTtyPFAo3dK0Y5D42raNq5UopJ42LNdZ8D0cc/fO2TJbyRM8Y1QhP3EF8A==",
+      "version": "5.0.82",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.82.tgz",
+      "integrity": "sha512-vdCUcpeTN7Cxuke16pZGQg4/zV0z3zs91AsLTkJ6HiOMnFDrqbWdDo+3FB5Mrw0Z6QnBKTUxeZ00K0vn6rgzlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api": "6.3.10",
-        "@aws-amplify/api-graphql": "4.7.14",
+        "@aws-amplify/api": "6.3.11",
+        "@aws-amplify/api-graphql": "4.7.15",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.79",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.79.tgz",
-      "integrity": "sha512-c4VDSj1qGhBusd1umv0GRP4oTPVChZO4YWFB5uMfNjPOw29IAkJssLfmDqJ1I/qqru0887ygq2MbEOs6/9ADjw==",
+      "version": "2.0.80",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.80.tgz",
+      "integrity": "sha512-6ePdufP1gwb//OvuyD/YsnXUvDRXd1sI3+R+Mu+R34IxL34hS1ovEJcM7aAEodvC9bc0jfcyGVoHLxFaRu2nYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.8.3.tgz",
-      "integrity": "sha512-ejaQQm5LzdF9/jBRCx89m60mna/sVFnvCxaQZnm3QtTXJbMhtv60iQQMr3UQ0EAs6UXbwYYF6jJXqcLU3qO63A==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.8.4.tgz",
+      "integrity": "sha512-aplukG1r4dAnKQmvTwc6zS9Oi3CuljRDbyxqTVKPv3oIqgZguTaWyfL6Ta+2XTj5fK816uLL7Rg15Lq1qvU0Ag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -3630,16 +3630,19 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -3768,9 +3771,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3802,53 +3805,54 @@
       }
     },
     "node_modules/@gbraver-burst-network/browser-sdk": {
-      "version": "1.16.22",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.16.22.tgz",
-      "integrity": "sha512-J/LBpbfDw1BWF4tT1vDP9qTApqylXhXI+AOYKgWsFcqzC8p+uKgLiL1xtXFFNGBeCrlot/ZeJMzu/UmCKLJ83Q==",
+      "version": "1.16.23",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.16.23.tgz",
+      "integrity": "sha512-PRXRpbM4gaCLS2T7ycvofIYlMXSPyfQj4+pceAJ4lslpLJCUQE1jEKUC3cnkWGNr2nFPJmcugZBu+Wqck8L0Ug==",
       "license": "MIT",
       "dependencies": {
-        "aws-amplify": "^6.14.3",
-        "gbraver-burst-core": "^1.36.1",
+        "aws-amplify": "^6.14.4",
+        "gbraver-burst-core": "^1.36.2",
         "rxjs": "^7.8.2",
-        "zod": "^3.24.3"
+        "zod": "^3.24.4"
       }
     },
     "node_modules/@html-eslint/eslint-plugin": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.39.0.tgz",
-      "integrity": "sha512-+VdSayjBCE/0cdqJu6YyVAVsduaegevPzWH9hGcKWRJEGu4fKVSRkiecVpznDtMCU8rVJNG8Yif0y+WI0UicNQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.40.0.tgz",
+      "integrity": "sha512-KzrNQpbVbQ621BzW8HiVOiY/JqC72evoZaXh2oYx1SZO6c7CDEb9sDbEyHg0ImdEoi6PghY6myY4qf+il31DzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/template-parser": "^0.39.0",
-        "@html-eslint/template-syntax-parser": "^0.39.0"
+        "@eslint/plugin-kit": "0.2.8",
+        "@html-eslint/template-parser": "^0.40.0",
+        "@html-eslint/template-syntax-parser": "^0.40.0"
       }
     },
     "node_modules/@html-eslint/parser": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.39.0.tgz",
-      "integrity": "sha512-dM4M/uhT+UWAVKO3Lg2ay46ZlCDzig1eVNxF91DxBpXMsH2esGAVNcDSspebyIebCxtK4gGoM3Ebxb/yNLmA1g==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.40.0.tgz",
+      "integrity": "sha512-xvySQLPogafK2aTOPBD6V7+4qpr1AnOZXO8zM2z0b4i3BB9ISk5PTWu5+ofOekKxjxUh7Z+QWaoezu1SIi33YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/template-syntax-parser": "^0.39.0",
-        "es-html-parser": "0.1.1"
+        "@html-eslint/template-syntax-parser": "^0.40.0",
+        "es-html-parser": "0.2.0"
       }
     },
     "node_modules/@html-eslint/template-parser": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.39.0.tgz",
-      "integrity": "sha512-OhltZNKZWO1y18Zb4qfSRuGmXmhnQgmgXGBniob03OOL26zUnsnrG2E3+fn3IUk4zu3KqqrfWNnllXgB/kaZ4Q==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.40.0.tgz",
+      "integrity": "sha512-f1S70T88yRe3zStT0CiDDgRw24Fgi1wgbW74YNUocEVuXvh2snxBEufY46Yg2udGlOz+SnQaygshacW45L+JWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-html-parser": "0.1.1"
+        "es-html-parser": "0.2.0"
       }
     },
     "node_modules/@html-eslint/template-syntax-parser": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.39.0.tgz",
-      "integrity": "sha512-3hE0AfpdZhJ6jBPxozvPD/5My9HM5YYf56PRrL+Tvk5p4NnRpqlm2claED75T2ne26zDiPk0pJ9oOo8huxR07Q==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.40.0.tgz",
+      "integrity": "sha512-Rq3UmjiWreKnXrN95Nt6vLlKgQrV8PhoYrlADn3u7X7vtgCccTmjV6aUHJCw7AyNXmcSNNpN2KPsBmQfH3y58A==",
       "dev": true,
       "license": "MIT"
     },
@@ -5005,6 +5009,299 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
+      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6668,21 +6965,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz",
-      "integrity": "sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz",
+      "integrity": "sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/type-utils": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/type-utils": "8.32.0",
+        "@typescript-eslint/utils": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6698,16 +6995,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.0.tgz",
-      "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz",
+      "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/typescript-estree": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6723,14 +7020,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.0.tgz",
+      "integrity": "sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0"
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6741,16 +7038,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.0.tgz",
-      "integrity": "sha512-DJ1N1GdjI7IS7uRlzJuEDCgDQix3ZVYVtgeWEyhyn4iaoitpMBX6Ndd488mXSx0xah/cONAkEaYyylDyAeHMHg==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.0.tgz",
+      "integrity": "sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
+        "@typescript-eslint/typescript-estree": "8.32.0",
+        "@typescript-eslint/utils": "8.32.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6765,9 +7062,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.0.tgz",
+      "integrity": "sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6779,20 +7076,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.0.tgz",
+      "integrity": "sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/visitor-keys": "8.32.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6832,16 +7129,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.0.tgz",
-      "integrity": "sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.0.tgz",
+      "integrity": "sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.32.0",
+        "@typescript-eslint/types": "8.32.0",
+        "@typescript-eslint/typescript-estree": "8.32.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6856,13 +7153,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.0.tgz",
+      "integrity": "sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
+        "@typescript-eslint/types": "8.32.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -7439,18 +7736,18 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.14.3.tgz",
-      "integrity": "sha512-HzK5uzpp0aAQTtqNcAHpfVCIcyfBAuJHfPD9s8fJn43YViB5eqLFe0OeXqrV/m8swqEFCbYXialMzqHNZXN6ZQ==",
+      "version": "6.14.4",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.14.4.tgz",
+      "integrity": "sha512-V1uRj0zg/pMsu0MWEg1tgUyR4YdO9Qfgo+P+tOtHUa0Id3SCWGnSaPCGQjIhli6kWHKT74vYsRwXdTfbKCA6xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.79",
-        "@aws-amplify/api": "6.3.10",
-        "@aws-amplify/auth": "6.12.3",
-        "@aws-amplify/core": "6.11.3",
-        "@aws-amplify/datastore": "5.0.81",
-        "@aws-amplify/notifications": "2.0.79",
-        "@aws-amplify/storage": "6.8.3",
+        "@aws-amplify/analytics": "7.0.80",
+        "@aws-amplify/api": "6.3.11",
+        "@aws-amplify/auth": "6.12.4",
+        "@aws-amplify/core": "6.11.4",
+        "@aws-amplify/datastore": "5.0.82",
+        "@aws-amplify/notifications": "2.0.80",
+        "@aws-amplify/storage": "6.8.4",
         "tslib": "^2.5.0"
       }
     },
@@ -8556,6 +8853,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -8942,9 +9253,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9582,9 +9893,9 @@
       }
     },
     "node_modules/es-html-parser": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.1.1.tgz",
-      "integrity": "sha512-SNHdEpKkN4nWZ3sFq9AxPlaUzPKJewGh59JrVS2355vELTOFygyf/lbfDDIONuGvYrhvAHoaUd+sK9UGaGrKUg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.2.0.tgz",
+      "integrity": "sha512-snJ7uJC8Dkx/yT0eYZrWcY57rkPU6Zui6YphPynw8r52AWf57gjqMC0GWe7OxSDipwXowFpa3rqckEeAPTOz7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9726,9 +10037,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
+      "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9738,11 +10049,12 @@
         "@eslint/config-helpers": "^0.2.1",
         "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
+        "@eslint/js": "9.26.0",
         "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -9766,7 +10078,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
+        "optionator": "^0.9.3",
+        "zod": "^3.24.2"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -9981,6 +10294,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
+      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
+      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10083,6 +10419,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -10641,13 +10993,13 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.36.1.tgz",
-      "integrity": "sha512-MIWLZWBOBt51q+tpc3iOb8dEj7/MkS8SEmUsTLm9QRYhnaB5k00g3axoS9hZxJNT7+W82ktrW2auarcSgwhtzA==",
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.36.2.tgz",
+      "integrity": "sha512-ML3W5EiOftFBltaG9a2L24VNLRwl6/4WP9fhgGUuJzcEJGi4V6eObgkv+7/lujb5z/nVIVo0bMJqM0u9q0fT1w==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.1",
-        "zod": "^3.24.3"
+        "zod": "^3.24.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -12444,6 +12796,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -14451,9 +14810,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14903,6 +15262,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -16910,6 +17279,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
@@ -17398,16 +17794,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18571,9 +19024,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18934,15 +19387,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.0.tgz",
-      "integrity": "sha512-u+93F0sB0An8WEAPtwxVhFby573E8ckdjwUUQUj9QA4v8JAvgtoDdIyYR3XFwFHq2W1KJ1AurwJCO+w+Y1ixyQ==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.0.tgz",
+      "integrity": "sha512-UMq2kxdXCzinFFPsXc9o2ozIpYCCOiEC46MG3yEh5Vipq6BO27otTtEBZA1fQ66DulEUgE97ucQ/3YY66CPg0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.31.0",
-        "@typescript-eslint/parser": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0"
+        "@typescript-eslint/eslint-plugin": "8.32.0",
+        "@typescript-eslint/parser": "8.32.0",
+        "@typescript-eslint/utils": "8.32.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19996,12 +20449,22 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.16.22",
+    "@gbraver-burst-network/browser-sdk": "1.16.23",
     "@tweenjs/tween.js": "^25.0.0",
-    "gbraver-burst-core": "1.36.1",
+    "gbraver-burst-core": "1.36.2",
     "handlebars": "^4.7.8",
     "howler": "^2.2.4",
     "jsqr": "^1.4.0",
@@ -25,11 +25,11 @@
     "workbox-precaching": "^7.3.0",
     "workbox-routing": "^7.3.0",
     "workbox-strategies": "^7.3.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.4"
   },
   "devDependencies": {
-    "@html-eslint/eslint-plugin": "^0.39.0",
-    "@html-eslint/parser": "^0.39.0",
+    "@html-eslint/eslint-plugin": "^0.40.0",
+    "@html-eslint/parser": "^0.40.0",
     "@storybook/addon-backgrounds": "^8.6.12",
     "@storybook/html": "^8.6.12",
     "@storybook/html-webpack5": "^8.6.12",
@@ -46,7 +46,7 @@
     "css-loader": "^7.1.2",
     "dependency-cruiser": "^16.10.1",
     "dotenv": "^16.5.0",
-    "eslint": "^9.25.1",
+    "eslint": "^9.26.0",
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "glob": "^11.0.2",
@@ -73,7 +73,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.31.0",
+    "typescript-eslint": "^8.32.0",
     "webpack": "^5.99.7",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"


### PR DESCRIPTION
Updates various dependencies to their latest versions.

This change includes updates to:
- @gbraver-burst-network/browser-sdk
- gbraver-burst-core
- zod
- @html-eslint/eslint-plugin
- @html-eslint/parser
- eslint
- typescript-eslint
- aws-amplify and its related modules.

These updates likely include bug fixes, performance improvements, and new features from the respective libraries.