### PR TITLE
グランドーザのNPCを弱体化させた

### DIFF
--- a/src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts
+++ b/src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts
@@ -68,13 +68,13 @@ const getDefenseRoutineCondition = (data: SimpleRoutineData) => ({
  */
 const defenseRoutine: SimpleRoutine = (data) => {
   const { enemy } = data;
-  const { battery1, battery2, minimumSurviveBattery, burst, pilot } =
+  const { battery1, minimumSurviveBattery, burst, pilot } =
     getDefenseRoutineCondition(data);
 
   let selectedCommand: Command = burst ??
     pilot ?? { type: "BATTERY_COMMAND", battery: enemy.armdozer.battery };
-  if (burst && pilot && enemy.armdozer.battery === 5 && battery2) {
-    selectedCommand = battery2;
+  if (burst && pilot && enemy.armdozer.battery === 5 && battery1) {
+    selectedCommand = battery1;
   } else if (enemy.armdozer.battery === 0 && burst) {
     selectedCommand = burst;
   } else if (battery1 && !burst && pilot) {


### PR DESCRIPTION
This pull request refactors the `gran-dozer-for-survive-super-power-with-guard` NPC logic by simplifying routines and optimizing battery command selection. The changes primarily involve removing unused code, modifying logic for attack and defense routines, and replacing specific battery commands to improve clarity and maintainability.

### Refactoring and Simplifications:

* Removed the `getMinimumBeatDownBattery` function and its associated logic from the attack routine, simplifying the condition checks for selecting commands. [[1]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L12) [[2]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L27-L31) [[3]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L41-R41)

* Replaced the `battery3` command with `battery2` in the defense routine condition, aligning the logic with updated requirements.

### Logic Adjustments:

* Adjusted the attack routine to directly calculate the battery value when the enemy's armdozer battery is greater than 1, removing reliance on the now-deprecated `minimumBeatDownBattery` logic.

* Updated the defense routine to prioritize `battery1` over `battery3` when the enemy's armdozer battery equals 5, ensuring more consistent behavior in edge cases.