### PR TITLE
グランドーザNPCを弱体化

### DIFF
--- a/src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts
+++ b/src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts
@@ -9,7 +9,6 @@ import {
 import { findBatteryCommand } from "./find-battery-command";
 import { findBurstCommand } from "./find-burst-command";
 import { findPilotSkillCommand } from "./find-pilot-skill-command";
-import { getMinimumSurvivableBattery } from "./get-minimum-survivable-battery";
 import { NPC } from "./npc";
 import { SimpleNPC, SimpleRoutine, SimpleRoutineData } from "./simple-npc";
 
@@ -22,6 +21,7 @@ const ZERO_BATTERY: Command = { type: "BATTERY_COMMAND", battery: 0 };
  * @returns 攻撃ルーチンの条件オブジェクト
  */
 const getAttackRoutineCondition = (data: SimpleRoutineData) => ({
+  battery1: findBatteryCommand(1, data.commands),
   battery5: findBatteryCommand(5, data.commands),
   burst: findBurstCommand(data.commands),
   pilot: findPilotSkillCommand(data.commands),
@@ -32,14 +32,11 @@ const getAttackRoutineCondition = (data: SimpleRoutineData) => ({
  * 攻撃ルーチン
  */
 const attackRoutine: SimpleRoutine = (data) => {
-  const { battery5, burst, pilot } = getAttackRoutineCondition(data);
+  const { battery1, battery5, burst, pilot } = getAttackRoutineCondition(data);
 
-  let selectedCommand: Command = ZERO_BATTERY;
+  let selectedCommand: Command = battery1 ?? ZERO_BATTERY;
   if (battery5 && pilot && burst) {
     selectedCommand = battery5;
-  } else if (1 < data.enemy.armdozer.battery) {
-    const battery = data.enemy.armdozer.battery - 1;
-    selectedCommand = { type: "BATTERY_COMMAND", battery };
   }
 
   return selectedCommand;
@@ -51,13 +48,7 @@ const attackRoutine: SimpleRoutine = (data) => {
  * @returns 防御ルーチンの条件オブジェクト
  */
 const getDefenseRoutineCondition = (data: SimpleRoutineData) => ({
-  minimumSurviveBattery: getMinimumSurvivableBattery(
-    data.enemy,
-    data.player,
-    data.player.armdozer.battery,
-  ),
-  battery1: findBatteryCommand(1, data.commands),
-  battery2: findBatteryCommand(2, data.commands),
+  battery3: findBatteryCommand(3, data.commands),
   burst: findBurstCommand(data.commands),
   pilot: findPilotSkillCommand(data.commands),
 });
@@ -68,19 +59,13 @@ const getDefenseRoutineCondition = (data: SimpleRoutineData) => ({
  */
 const defenseRoutine: SimpleRoutine = (data) => {
   const { enemy } = data;
-  const { battery1, minimumSurviveBattery, burst, pilot } =
-    getDefenseRoutineCondition(data);
+  const { battery3, burst, pilot } = getDefenseRoutineCondition(data);
 
-  let selectedCommand: Command = burst ??
-    pilot ?? { type: "BATTERY_COMMAND", battery: enemy.armdozer.battery };
-  if (burst && pilot && enemy.armdozer.battery === 5 && battery1) {
-    selectedCommand = battery1;
-  } else if (enemy.armdozer.battery === 0 && burst) {
-    selectedCommand = burst;
-  } else if (battery1 && !burst && pilot) {
-    selectedCommand = pilot;
-  } else if (minimumSurviveBattery.isExist) {
-    const { value: battery } = minimumSurviveBattery;
+  let selectedCommand: Command = burst ?? pilot ?? ZERO_BATTERY;
+  if (burst && pilot && enemy.armdozer.battery === 5 && battery3) {
+    selectedCommand = battery3;
+  } else if (1 < enemy.armdozer.battery) {
+    const battery = enemy.armdozer.battery;
     selectedCommand = { type: "BATTERY_COMMAND", battery };
   }
 


### PR DESCRIPTION
This pull request refactors the `GranDozer` NPC routines by simplifying logic, removing unused code, and improving maintainability. Key changes include the removal of the `getMinimumSurvivableBattery` function, updates to battery command handling, and adjustments to attack and defense routines.

### Code cleanup and removal of unused functionality:
* Removed the `getMinimumSurvivableBattery` import and its usage in the defense routine, as it is no longer required for determining survivability conditions. (`src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts`, [[1]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L12) [[2]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L54-R51)

### Updates to attack routine:
* Added support for a `battery1` command in the `getAttackRoutineCondition` function and updated the attack routine to prioritize `battery1` over the default `ZERO_BATTERY` when no higher-priority commands are available. (`src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts`, [[1]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630R24) [[2]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L35-L42)

### Updates to defense routine:
* Replaced `battery1` and `battery2` commands with `battery3` in the `getDefenseRoutineCondition` function and updated the defense routine logic to use `battery3` when specific conditions are met. (`src/js/npc/gran-dozer-for-survive-super-power-with-guard.ts`, [[1]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L54-R51) [[2]](diffhunk://#diff-7a3900e237861ef62181a8ee643d4f87e78ed6c130f1e54f22ba0402e606f630L71-R68)