### PR TITLE
stateHistoryUntilNowを追加した

### DIFF
--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -57,6 +57,8 @@ export type CustomStateAnimation = CustomBattleEventProps & {
   readonly update: GameState[];
   /** コマンド入力から現在のステートまでの更新履歴 */
   readonly updateUntilNow: GameState[];
+  /** 現在のステートまでの更新履歴 */
+  readonly stateHistoryUntilNow: GameState[];
 };
 
 /** 最終ステート系イベントのプロパティ */

--- a/src/js/td-scenes/battle/procedure/play-state-history.ts
+++ b/src/js/td-scenes/battle/procedure/play-state-history.ts
@@ -47,11 +47,22 @@ export async function playStateHistory(
           parallelPlayEffects.includes(next.effect.name) &&
           parallelPlayEffects.includes(gameState.effect.name);
         const updateUntilNow = gameStateHistory.slice(0, index + 1);
+        const previousStateHistoryLength =
+          props.stateHistory.length - gameStateHistory.length;
+        const previousStateHistory = props.stateHistory.slice(
+          0,
+          previousStateHistoryLength,
+        );
+        const stateHistoryUntilNow = [
+          ...previousStateHistory,
+          ...updateUntilNow,
+        ];
         const customStateAnimationProps = {
           ...props,
           currentState: gameState,
           update: gameStateHistory,
           updateUntilNow,
+          stateHistoryUntilNow,
         };
         const anime = all(
           stateAnimation(props, gameState),


### PR DESCRIPTION
This pull request introduces a new property, `stateHistoryUntilNow`, to enhance the handling of game state updates in the battle system. The property consolidates the full history of game states up to the current point, improving the clarity and functionality of state management in custom battle events.

### Enhancements to game state management:

* **Added `stateHistoryUntilNow` property**:
  - In `src/js/td-scenes/battle/custom-battle-event.ts`, a new property `stateHistoryUntilNow` was added to the `CustomStateAnimation` type, representing the full history of game states up to the current point.
  - In `src/js/td-scenes/battle/procedure/play-state-history.ts`, logic was added to compute `stateHistoryUntilNow` by combining the previous state history with the current updates, and it was included in the `customStateAnimationProps` object.