### PR TITLE
StateAnimationTypeContainerを追加した

### DIFF
--- a/src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.ts
@@ -2,7 +2,7 @@ import { Animate } from "../../../animation/animate";
 import { empty } from "../../../animation/delay";
 import { CustomStateAnimation } from "../../../td-scenes/battle/custom-battle-event";
 import { tsubasaFirstAttackShout } from "../animation/tsubasa-first-attack-shout";
-import { StateAnimationType } from "../state-animation-type";
+import { StateAnimationTypeContainer } from "../state-animation-type";
 
 /**
  * カスタムステートアニメーション
@@ -10,9 +10,7 @@ import { StateAnimationType } from "../state-animation-type";
  * @returns カスタムステートアニメーション
  */
 export function onStateAnimation(
-  props: CustomStateAnimation & {
-    stateAnimationType: StateAnimationType;
-  },
+  props: Readonly<CustomStateAnimation & StateAnimationTypeContainer>,
 ): Animate {
   const { stateAnimationType } = props;
   switch (stateAnimationType) {

--- a/src/js/custom-battle-events/survive-super-power-with-guard/props.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/props.ts
@@ -1,21 +1,20 @@
 import { LastStateConditionContainer } from "./last-state-condition";
 import { SurviveSuperPowerWithGuardState } from "./state";
-import { StateAnimationType } from "./state-animation-type";
+import { StateAnimationTypeContainer } from "./state-animation-type";
 
 /** 「超火力はガードで凌げ」用のプロパティ */
 export type SurviveSuperPowerWithGuardProps =
   /**
-   * LastState系イベントで利用する条件判断オブジェクト
-   * 本プロパティはbeforeLastStateが呼び出されるたびに更新される想定
-   * イベントが実行されていない場合、本プロパティはundefined
+   * アニメーション種別条件判断オブジェクト
+   * 本プロパティはonStateAnimationが呼び出されるたびに更新される想定
    */
-  Partial<LastStateConditionContainer> & {
-    /** ステート */
-    state: SurviveSuperPowerWithGuardState;
-
+  StateAnimationTypeContainer &
     /**
-     * アニメーション種別条件判断オブジェクト
-     * 本プロパティはonStateAnimationが呼び出されるたびに更新される想定
+     * LastState系イベントで利用する条件判断オブジェクト
+     * 本プロパティはbeforeLastStateが呼び出されるたびに更新される想定
+     * イベントが実行されていない場合、本プロパティはundefined
      */
-    stateAnimationType: StateAnimationType;
-  };
+    Partial<LastStateConditionContainer> & {
+      /** ステート */
+      state: SurviveSuperPowerWithGuardState;
+    };

--- a/src/js/custom-battle-events/survive-super-power-with-guard/state-animation-type.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/state-animation-type.ts
@@ -3,6 +3,12 @@ import { PlayerState } from "gbraver-burst-core";
 /** カスタムステートアニメーション種別 */
 export type StateAnimationType = "TsubasaFirstAttack" | "None";
 
+/** カスタムステートアニメーション種別のプロパティを持つオブジェクト */
+export type StateAnimationTypeContainer = {
+  /** カスタムステートアニメーション種別 */
+  stateAnimationType: StateAnimationType;
+};
+
 /** アニメーション種別条件判断オブジェクト */
 export type StateAnimationTypeCondition = {
   /** プレイヤー */


### PR DESCRIPTION
This pull request refactors how the `StateAnimationType` is handled by introducing a new container type, `StateAnimationTypeContainer`, and updating related files to use this new type. This change improves type safety and clarifies the structure of objects that include animation type information.

### Refactoring of `StateAnimationType`:

* **Introduction of `StateAnimationTypeContainer`:**
  - Added a new type, `StateAnimationTypeContainer`, which encapsulates the `stateAnimationType` property. This provides a more structured way to handle objects with animation type information. (`src/js/custom-battle-events/survive-super-power-with-guard/state-animation-type.ts`, [src/js/custom-battle-events/survive-super-power-with-guard/state-animation-type.tsR6-R11](diffhunk://#diff-a2118b0488013cf95bbb26bae0e7d767730417f1436675d188944d7972eb6a99R6-R11))

* **Updates to `onStateAnimation` function:**
  - Updated the `props` parameter to use `Readonly<CustomStateAnimation & StateAnimationTypeContainer>` instead of embedding `stateAnimationType` directly. This ensures immutability and consistency in type definitions. (`src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.ts`, [src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.tsL5-R13](diffhunk://#diff-d499c51245c4025944dcd16628c01bc88cb76f631ed85752b69d50f95ff51e92L5-R13))

### Updates to `SurviveSuperPowerWithGuardProps`:

* **Replacement of `stateAnimationType` with `StateAnimationTypeContainer`:**
  - Replaced the direct `stateAnimationType` property with the new `StateAnimationTypeContainer` in the `SurviveSuperPowerWithGuardProps` type. This aligns the type with the new container-based approach. (`src/js/custom-battle-events/survive-super-power-with-guard/props.ts`, [[1]](diffhunk://#diff-ffc4d3ffc7070bf590513ee3fc1df7393a559965f8cbced6b2a8d3cda52a1b5aL3-R11) [[2]](diffhunk://#diff-ffc4d3ffc7070bf590513ee3fc1df7393a559965f8cbced6b2a8d3cda52a1b5aL15-L20)