### PR TITLE
ターン開始時にメッセージウインドウを消す処理を追加した

### DIFF
--- a/src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/procedures/on-state-animation.ts
@@ -1,17 +1,18 @@
 import { Animate } from "../../../animation/animate";
 import { empty } from "../../../animation/delay";
 import { CustomStateAnimation } from "../../../td-scenes/battle/custom-battle-event";
+import { invisibleShoutMessageWindowWhenTurnChange } from "../../invisible-shout-message-window";
 import { tsubasaFirstAttackShout } from "../animation/tsubasa-first-attack-shout";
 import { StateAnimationTypeContainer } from "../state-animation-type";
 
 /**
- * カスタムステートアニメーション
+ * アニメーション種別に応じたアニメーションを取得する
  * @param props イベントプロパティ
- * @returns カスタムステートアニメーション
+ * @returns アニメーション
  */
-export function onStateAnimation(
+function getAnimate(
   props: Readonly<CustomStateAnimation & StateAnimationTypeContainer>,
-): Animate {
+) {
   const { stateAnimationType } = props;
   switch (stateAnimationType) {
     case "TsubasaFirstAttack":
@@ -20,3 +21,13 @@ export function onStateAnimation(
       return empty();
   }
 }
+
+/**
+ * カスタムステートアニメーション
+ * @param props イベントプロパティ
+ * @returns カスタムステートアニメーション
+ */
+export const onStateAnimation = (
+  props: Readonly<CustomStateAnimation & StateAnimationTypeContainer>,
+): Animate =>
+  invisibleShoutMessageWindowWhenTurnChange(props) ?? getAnimate(props);


### PR DESCRIPTION
Delegates state animation retrieval to a dedicated function.

Introduces a higher-order function to optionally hide the shout message window when the turn changes, enhancing the visual flow of the battle.