### PR TITLE
シンヤのセリフを修正

### DIFF
--- a/src/js/custom-battle-events/battery-system-tutorial/animation/shinya-pilot-skill-shout.ts
+++ b/src/js/custom-battle-events/battery-system-tutorial/animation/shinya-pilot-skill-shout.ts
@@ -15,6 +15,6 @@ export const shinyaPilotSkillShout = (
     playerPilotOnlyShout(
       props,
       "Shinya",
-      `なぜか${wbr}無性に${wbr}やる気が${wbr}出てきたッス`,
+      `何故か${wbr}やる気が${wbr}出てきたッス`,
     );
   });

--- a/src/js/custom-battle-events/burst-tutorial/animation/shinya-shout-when-self-initiated-pilot-skill.ts
+++ b/src/js/custom-battle-events/burst-tutorial/animation/shinya-shout-when-self-initiated-pilot-skill.ts
@@ -11,6 +11,6 @@ export const shinyaShoutWhenSelfInitiatedPilotSkill = (
     playerPilotOnlyShout(
       props,
       "Shinya",
-      `何故か${wbr}無性に${wbr}やる気が${wbr}出てきたッス`,
+      `何故か${wbr}やる気が${wbr}出てきたッス`,
     );
   });


### PR DESCRIPTION
This pull request includes minor changes to unify the phrasing of a character's dialogue in two animation files. The updates remove the word "無性に" (which roughly translates to "for no particular reason") from the dialogue to make it more concise and consistent.

Dialogue updates:

* [`src/js/custom-battle-events/battery-system-tutorial/animation/shinya-pilot-skill-shout.ts`](diffhunk://#diff-ce18922d64178e6d508cbdced7ee33c8bb11045b039424ae1aae5491339a1264L18-R18): Updated Shinya's dialogue to remove "無性に" for a more concise phrasing.
* [`src/js/custom-battle-events/burst-tutorial/animation/shinya-shout-when-self-initiated-pilot-skill.ts`](diffhunk://#diff-d6de332b2657fa75c8b486ed9ac4d02572a3950c3cb1a8c989d281137f1b42c8L14-R14): Updated Shinya's dialogue to match the phrasing in the other file.