### PR TITLE
ボタンアイコンにaria-hidden属性を追加してアクセシビリティを向上

### DIFF
--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -93,23 +93,35 @@
   </div>
   <div class="{{ROOT_CLASS}}__game-menu">
     <button class="{{ROOT_CLASS}}__config" data-id="{{ids.config}}">
-      <span class="{{ROOT_CLASS}}__menu-button-icon">⚙️</span>
+      <span
+        class="{{ROOT_CLASS}}__menu-button-icon"
+        aria-hidden="true"
+      >⚙️</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">設定</span>
     </button>
     <button class="{{netBattleClassName}}" data-id="{{ids.netBattle}}">
-      <span class="{{ROOT_CLASS}}__menu-button-icon">🌐</span>
+      <span
+        class="{{ROOT_CLASS}}__menu-button-icon"
+        aria-hidden="true"
+      >🌐</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">ネット対戦</span>
     </button>
     <button class="{{ROOT_CLASS}}__arcade" data-id="{{ids.arcade}}">
-      <span class="{{ROOT_CLASS}}__menu-button-icon">🕹</span>
+      <span
+        class="{{ROOT_CLASS}}__menu-button-icon"
+        aria-hidden="true"
+      >🕹</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">アーケード</span>
     </button>
     <button class="{{ROOT_CLASS}}__story" data-id="{{ids.story}}">
-      <span class="{{ROOT_CLASS}}__menu-button-icon">📖</span>
+      <span
+        class="{{ROOT_CLASS}}__menu-button-icon"
+        aria-hidden="true"
+      >📖</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">ストーリー</span>
     </button>
     <button class="{{ROOT_CLASS}}__tutorial" data-id="{{ids.tutorial}}">
-      <span class="{{ROOT_CLASS}}__tutorial-icon">🔰</span>
+      <span class="{{ROOT_CLASS}}__tutorial-icon" aria-hidden="true">🔰</span>
       <span class="{{ROOT_CLASS}}__tutorial-label">チュートリアル</span>
     </button>
   </div>


### PR DESCRIPTION
This pull request improves accessibility by adding `aria-hidden="true"` attributes to decorative icons in the `src/js/dom-scenes/title/dom/root-inner-html.hbs` file. This ensures that screen readers ignore these icons, focusing instead on the accompanying text labels.

Accessibility improvements:

* Added `aria-hidden="true"` to all decorative `<span>` elements with class `{{ROOT_CLASS}}__menu-button-icon` and `{{ROOT_CLASS}}__tutorial-icon` to prevent screen readers from announcing these icons.