### PR TITLE
タイトル画面を調整した

### DIFF
--- a/src/css/title.css
+++ b/src/css/title.css
@@ -243,7 +243,7 @@
   grid-template:
     "net-battle story  tutorial" 1fr
     "config     arcade tutorial" 1fr / 1fr 1fr 1fr;
-  gap: calc(var(--responsive-font-size) * 0.5);
+  gap: calc(var(--responsive-font-size) * 0.3);
 }
 
 .title__config,
@@ -253,6 +253,7 @@
   border: var(--sub-button-border);
   background-color: var(--sub-button-background-color);
   font-size: calc(var(--responsive-font-size));
+  min-height: calc(var(--responsive-font-size) * 3);
   border-radius: var(--button-border-radius);
   color: var(--button-font-color);
   box-shadow: var(--sub-button-box-shadow);
@@ -260,7 +261,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: calc(var(--responsive-font-size) * 0.5);
 }
 
 .title__config {

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -185,7 +185,7 @@
 }
 
 .title__neo-landozer {
-  --size: min(150vh, 100vw);
+  --size: min(150vh, 90vw);
 
   position: fixed;
   top: 0;
@@ -195,7 +195,7 @@
 }
 
 .title__shin-braver {
-  --size: min(150vh, 100vw);
+  --size: min(150vh, 90vw);
 
   position: fixed;
   top: 0;

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -185,21 +185,21 @@
 }
 
 .title__neo-landozer {
-  --size: 80vw;
+  --size: min(150vh, 100vw);
 
   position: fixed;
   top: 0;
-  right: calc(50vw - 25vh);
+  right: calc(50vw - 30vh);
   width: var(--size);
   height: var(--size);
 }
 
 .title__shin-braver {
-  --size: 80vw;
+  --size: min(150vh, 100vw);
 
   position: fixed;
   top: 0;
-  left: calc(50vw - 25vh);
+  left: calc(50vw - 30vh);
   transform: scaleX(-1);
   width: var(--size);
   height: var(--size);

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -185,21 +185,21 @@
 }
 
 .title__neo-landozer {
-  --size: 90vw;
+  --size: 80vw;
 
   position: fixed;
   top: 0;
-  right: calc(50vw - 30vh);
+  right: calc(50vw - 25vh);
   width: var(--size);
   height: var(--size);
 }
 
 .title__shin-braver {
-  --size: 90vw;
+  --size: 80vw;
 
   position: fixed;
   top: 0;
-  left: calc(50vw - 30vh);
+  left: calc(50vw - 25vh);
   transform: scaleX(-1);
   width: var(--size);
   height: var(--size);

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -185,7 +185,7 @@
 }
 
 .title__neo-landozer {
-  --size: 150vh;
+  --size: 90vw;
 
   position: fixed;
   top: 0;
@@ -195,7 +195,7 @@
 }
 
 .title__shin-braver {
-  --size: 150vh;
+  --size: 90vw;
 
   position: fixed;
   top: 0;

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -215,7 +215,7 @@
   box-sizing: border-box;
   padding: var(--screen-padding-top) var(--screen-padding-right)
     var(--screen-padding-bottom) var(--screen-padding-left);
-  gap: calc(var(--responsive-font-size) * 1.6);
+  gap: calc(var(--responsive-font-size) * 1);
 }
 
 .title__title {
@@ -227,7 +227,7 @@
 }
 
 .title__title-logo {
-  height: 35vh;
+  height: 30vh;
 }
 
 .title__copy-rights,


### PR DESCRIPTION
This pull request includes several updates to the `src/css/title.css` file to improve responsiveness and visual consistency. The changes primarily focus on adjusting element sizes, spacing, and layout gaps for better adaptability across different screen sizes.

### Responsiveness improvements:
* Updated the `--size` variable for `.title__neo-landozer` and `.title__shin-braver` to use `min(150vh, 90vw)` for better scaling on smaller screens. [[1]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L188-R188) [[2]](diffhunk://#diff-fa4f36644ae2a80b94771dd0423d70dc0ec869f3d8c966d0a6386bd80e754070L198-R198)
* Reduced the `height` of `.title__title-logo` from `35vh` to `30vh` to optimize its size on various screen dimensions.

### Spacing adjustments:
* Reduced the `gap` in the main container layout from `calc(var(--responsive-font-size) * 1.6)` to `calc(var(--responsive-font-size) * 1)` for tighter spacing.
* Adjusted the `gap` in the grid layout from `calc(var(--responsive-font-size) * 0.5)` to `calc(var(--responsive-font-size) * 0.3)` for a more compact design.

### Button styling:
* Added a `min-height` property to buttons (`calc(var(--responsive-font-size) * 3)`) to ensure consistent sizing across different font sizes.