### PR TITLE
各種イベントプロパティにメインターン数を追加した

### DIFF
--- a/src/js/custom-battle-events/separate-players.ts
+++ b/src/js/custom-battle-events/separate-players.ts
@@ -30,6 +30,26 @@ export function separatePlayers(
 }
 
 /**
+ * プレイヤーを自キャラ、敵に分割する、分割できない場合は例外を投げる
+ * @param props カスタムバトルイベントプロパティ
+ * @param state ゲームステート
+ * @returns 分割されたプレイヤー
+ */
+export const separatePlayersOrThrow = (
+  props: Readonly<CustomBattleEventProps>,
+  state: Readonly<GameState>,
+): SeparatedPlayers => {
+  const separated = separatePlayers(props, state);
+  if (!separated) {
+    throw new Error(
+      `Failed to separate players: playerId=${props.playerId}, enemyId=${props.enemyId}`,
+    );
+  }
+  return separated;
+};
+
+/**
+ * @deprecated
  * 最終ステートからプレイヤーを自キャラ、敵に分割する
  * @param props カスタムバトルイベントプロパティ
  * @returns 分割されたプレイヤー、分割できない場合null
@@ -39,6 +59,7 @@ export const separatePlayersFromLastState = (
 ) => separatePlayers(props, props.lastState);
 
 /**
+ * @deprecated
  * 現在ステートからプレイヤーを自キャラ、敵に分割する
  * @param props カスタムバトルイベントプロパティ
  * @returns 分割されたプレイヤー、分割できない場合null

--- a/src/js/custom-battle-events/separate-players.ts
+++ b/src/js/custom-battle-events/separate-players.ts
@@ -30,25 +30,6 @@ export function separatePlayers(
 }
 
 /**
- * プレイヤーを自キャラ、敵に分割する、分割できない場合は例外を投げる
- * @param props カスタムバトルイベントプロパティ
- * @param state ゲームステート
- * @returns 分割されたプレイヤー
- */
-export const separatePlayersOrThrow = (
-  props: Readonly<CustomBattleEventProps>,
-  state: Readonly<GameState>,
-): SeparatedPlayers => {
-  const separated = separatePlayers(props, state);
-  if (!separated) {
-    throw new Error(
-      `Failed to separate players: playerId=${props.playerId}, enemyId=${props.enemyId}`,
-    );
-  }
-  return separated;
-};
-
-/**
  * @deprecated
  * 最終ステートからプレイヤーを自キャラ、敵に分割する
  * @param props カスタムバトルイベントプロパティ

--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -60,6 +60,16 @@ export type CustomStateAnimationProps = CustomBattleEventProps & {
   readonly updateUntilNow: GameState[];
   /** 現在のステートまでの更新履歴 */
   readonly stateHistoryUntilNow: GameState[];
+
+  /** プレイヤーのステート */
+  readonly player: PlayerState;
+  /** プレイヤーのメインターン数 */
+  readonly playerMainTurnCount: number;
+
+  /** 敵のステート */
+  readonly enemy: PlayerState;
+  /** 敵のメインターン数 */
+  readonly enemyMainTurnCount: number;
 };
 
 /** 最終ステート系イベントのプロパティ */

--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -4,6 +4,7 @@ import {
   GameState,
   PilotSkillCommand,
   PlayerId,
+  PlayerState,
 } from "gbraver-burst-core";
 import { Observable } from "rxjs";
 
@@ -64,6 +65,16 @@ export type CustomStateAnimationProps = CustomBattleEventProps & {
 /** 最終ステート系イベントのプロパティ */
 export type LastStateEventProps = CustomBattleEventProps &
   LastStateContainer & {
+    /** プレイヤーのステート */
+    readonly player: PlayerState;
+    /** プレイヤーのメインターン数 */
+    readonly playerMainTurnCount: number;
+
+    /** 敵のステート */
+    readonly enemy: PlayerState;
+    /** 敵のメインターン数 */
+    readonly enemyMainTurnCount: number;
+
     /** コマンド入力から最終ステートまでのステート更新履歴 */
     readonly update: GameState[];
   };

--- a/src/js/td-scenes/battle/procedure/play-state-history.ts
+++ b/src/js/td-scenes/battle/procedure/play-state-history.ts
@@ -34,11 +34,6 @@ export async function playStateHistory(
     return;
   }
 
-  const separatedPlayersFromLastState = separatePlayers(props, lastState);
-  if (!separatedPlayersFromLastState) {
-    return;
-  }
-
   props.customBattleEvent?.onStateUpdateStarted({
     ...props,
     update: gameStateHistory,
@@ -65,12 +60,27 @@ export async function playStateHistory(
           ...previousStateHistory,
           ...updateUntilNow,
         ];
+        const separatedPlayers = separatePlayers(props, gameState);
+        const player = separatedPlayers?.player ?? gameState.players[0];
+        const playerMainTurnCount = getMainTurnCount({
+          stateHistory: gameStateHistory,
+          playerId: player.playerId,
+        });
+        const enemy = separatedPlayers?.enemy ?? gameState.players[1];
+        const enemyMainTurnCount = getMainTurnCount({
+          stateHistory: gameStateHistory,
+          playerId: enemy.playerId,
+        });
         const customStateAnimationProps = {
           ...props,
           currentState: gameState,
           update: gameStateHistory,
           updateUntilNow,
           stateHistoryUntilNow,
+          player,
+          playerMainTurnCount,
+          enemy,
+          enemyMainTurnCount,
         };
         const anime = all(
           stateAnimation(props, gameState),
@@ -97,18 +107,22 @@ export async function playStateHistory(
       ),
   );
 
+  const separatedPlayersFromLastState = separatePlayers(props, lastState);
+  const player = separatedPlayersFromLastState?.player ?? lastState.players[0];
+  const enemy = separatedPlayersFromLastState?.enemy ?? lastState.players[1];
   const playerMainTurnCount = getMainTurnCount({
     stateHistory: gameStateHistory,
-    playerId: separatedPlayersFromLastState.player.playerId,
+    playerId: player.playerId,
   });
   const enemyMainTurnCount = getMainTurnCount({
     stateHistory: gameStateHistory,
-    playerId: separatedPlayersFromLastState.enemy.playerId,
+    playerId: enemy.playerId,
   });
   const eventProps = {
     ...props,
-    ...separatedPlayersFromLastState,
+    player,
     playerMainTurnCount,
+    enemy,
     enemyMainTurnCount,
     update: gameStateHistory,
     lastState,


### PR DESCRIPTION
This pull request introduces enhancements to the handling of player and enemy states in custom battle events, alongside marking certain methods as deprecated. The changes aim to improve the clarity and functionality of state management while preparing for future updates.

### Deprecation of Methods:
* Marked `separatePlayers` and `separatePlayersFromLastState` as deprecated in `src/js/custom-battle-events/separate-players.ts`. These methods are still functional but are flagged for future removal or replacement. [[1]](diffhunk://#diff-81de306abdb3fa0b0a3bafde29bcf0ccbbf0c66c379e15436e0cb91c3ffcc806R33) [[2]](diffhunk://#diff-81de306abdb3fa0b0a3bafde29bcf0ccbbf0c66c379e15436e0cb91c3ffcc806R43)

### Enhancements to State Management:
* **New Properties in Type Definitions**: Added `player`, `playerMainTurnCount`, `enemy`, and `enemyMainTurnCount` to `CustomStateAnimationProps` and `LastStateEventProps` in `src/js/td-scenes/battle/custom-battle-event.ts` to better represent player and enemy states and their respective turn counts.
* **Integration in `playStateHistory`**: Updated `playStateHistory` in `src/js/td-scenes/battle/procedure/play-state-history.ts` to calculate and include player and enemy states, along with their main turn counts, using `separatePlayers` and `getMainTurnCount`. These properties are now passed to custom battle event handlers and animations. [[1]](diffhunk://#diff-572b9521c3c605438249e352706ab0c8ac0f381a7275e45700a83298f3b98135R63-R83) [[2]](diffhunk://#diff-572b9521c3c605438249e352706ab0c8ac0f381a7275e45700a83298f3b98135L92-R129)

### Import Adjustments:
* Added imports for `getMainTurnCount` and `separatePlayers` in `src/js/td-scenes/battle/procedure/play-state-history.ts` to support the new functionality.