### PR TITLE
iPad、iPhoneでHome画面に移動、Safariに復帰した場合に音が鳴らない不具合を修正した

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -12,27 +12,34 @@ const onHidden = () => {
 };
 
 /**
+ * HowlerのAudioContextがsuspendedならWebAudioContextをresumeする
+ *
+ * この関数はトップレベルで宣言し、addEventListenerのコールバックとして直接渡すことで、
+ * 同じ関数・同じオプションでの重複登録を防いでいる。
+ *
+ * MDN EventTarget: addEventListener() メソッドより引用
+ * https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener
+ * > addEventListener() メソッドは、関数または handleEvent() 関数を実装したオブジェクトを、
+ * > 呼び出される EventTarget における指定されたイベント種別のイベントリスナーのリストに加えることで動作します。
+ * > その関数やオブジェクトが既にターゲットのイベントリスナーのリストにあった場合は、
+ * > その関数やオブジェクトが二重に追加されることはありません。
+ */
+const resumeHowlerAudioContextOnTouch = () => {
+  if (Howler.ctx.state === "suspended") {
+    Howler.ctx.resume();
+  }
+};
+
+/**
  * visibilityState = "visible" の場合の処理
  */
 const onVisible = () => {
   console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
   Howler.mute(false);
-  document.addEventListener(
-    "touchstart",
-    () => {
-      if (Howler.ctx.state === "suspended") {
-        Howler.ctx
-          .resume()
-          .then(() => {
-            console.log("Audio context resumed");
-          })
-          .catch((error) => {
-            console.error("Failed to resume audio context:", error);
-          });
-      }
-    },
-    { once: true, capture: true },
-  );
+  document.addEventListener("touchstart", resumeHowlerAudioContextOnTouch, {
+    once: true,
+    capture: true,
+  });
 };
 
 /** オプション */

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -7,7 +7,7 @@ import { GameProps } from "../../game-props";
  * visibilityState = "hidden" の場合の処理
  */
 const onHidden = () => {
-  console.log("visibilityState = hidden", Howler.ctx); // TODO: ログ出力を削除する
+  console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
   Howler.mute(true);
 };
 
@@ -15,7 +15,7 @@ const onHidden = () => {
  * visibilityState = "visible" の場合の処理
  */
 const onVisible = () => {
-  console.log("visibilityState = visible", Howler.ctx); // TODO: ログ出力を削除する
+  console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
   Howler.mute(false);
 };
 

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -8,7 +8,7 @@ import { GameProps } from "../../game-props";
  */
 const onHidden = () => {
   console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
-  // Howler.mute(true);
+  Howler.mute(true);
 };
 
 /**
@@ -16,12 +16,23 @@ const onHidden = () => {
  */
 const onVisible = () => {
   console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
-  // // @ts-expect-error: _autoResumeの存在チェック
-  // if (typeof Howler._autoResume === "function") {
-  //   // @ts-expect-error: _autoResumeはHowlerの内部メソッドだが、必要なため呼び出す
-  //   Howler._autoResume();
-  // }
-  // Howler.mute(false);
+  Howler.mute(false);
+  document.addEventListener(
+    "touchstart",
+    () => {
+      if (Howler.ctx.state === "suspended") {
+        Howler.ctx
+          .resume()
+          .then(() => {
+            console.log("Audio context resumed");
+          })
+          .catch((error) => {
+            console.error("Failed to resume audio context:", error);
+          });
+      }
+    },
+    { once: true },
+  );
 };
 
 /** オプション */

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -17,7 +17,21 @@ const onHidden = () => {
 const onVisible = () => {
   console.log("visibilityState = visible"); // TODO: ログ出力を削除する
   Howler.mute(false);
-  Howler.ctx.resume();
+  if (Howler.ctx && typeof Howler.ctx.resume === "function") {
+    Howler.ctx.resume().catch(() => {
+      // resume失敗時はユーザー操作で再試行
+      const tryResume = () => {
+        Howler.ctx.resume().then(() => {
+          // ここで再生中の音があれば再度play()を呼ぶ必要がある場合はここで呼ぶ
+        }).finally(() => {
+          document.body.removeEventListener("touchend", tryResume);
+          document.body.removeEventListener("mousedown", tryResume);
+        });
+      };
+      document.body.addEventListener("touchend", tryResume, { once: true });
+      document.body.addEventListener("mousedown", tryResume, { once: true });
+    });
+  }
 };
 
 /** オプション */

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -3,6 +3,21 @@ import { Howler } from "howler";
 import { VisibilityChange } from "../../game-actions/visibility-change";
 import { GameProps } from "../../game-props";
 
+/**
+ * visibilityState = "hidden" の場合の処理
+ */
+const onHidden = () => {
+  Howler.mute(true);
+};
+
+/**
+ * visibilityState = "visible" の場合の処理
+ */
+const onVisible = () => {
+  Howler.mute(false);
+  Howler.ctx.resume();
+};
+
 /** オプション */
 type Options = {
   /** ゲームプロパティ */
@@ -18,6 +33,9 @@ type Options = {
 export function onVisibilityChange(
   options: Options, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void {
-  const shouldMute = document.visibilityState === "hidden";
-  Howler.mute(shouldMute);
+  if (document.visibilityState === "hidden") {
+    onHidden();
+  } else {
+    onVisible();
+  }
 }

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -34,6 +34,10 @@ const resumeHowlerAudioContextOnTouch = () => {
  */
 const onVisible = () => {
   Howler.mute(false);
+  // iPad、iPhoneなどのタッチデバイスではHome画面からの復帰時に
+  // WebAudioContextがsuspended状態になることがある。
+  // しかしユーザーインタラクションがないとWebAudioContextはresumeされないため、
+  // touchstartイベント(iPad、iPhoneではユーザーインタラクションと見なされる)でresumeする。
   document.addEventListener("touchstart", resumeHowlerAudioContextOnTouch, {
     once: true,
     capture: true,

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -31,7 +31,7 @@ const onVisible = () => {
           });
       }
     },
-    { once: true },
+    { once: true, capture: true },
   );
 };
 

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -8,7 +8,7 @@ import { GameProps } from "../../game-props";
  */
 const onHidden = () => {
   console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
-  Howler.mute(true);
+  // Howler.mute(true);
 };
 
 /**
@@ -16,12 +16,12 @@ const onHidden = () => {
  */
 const onVisible = () => {
   console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
-  // @ts-expect-error: _autoResumeの存在チェック
-  if (typeof Howler._autoResume === "function") {
-    // @ts-expect-error: _autoResumeはHowlerの内部メソッドだが、必要なため呼び出す
-    Howler._autoResume();
-  }
-  Howler.mute(false);
+  // // @ts-expect-error: _autoResumeの存在チェック
+  // if (typeof Howler._autoResume === "function") {
+  //   // @ts-expect-error: _autoResumeはHowlerの内部メソッドだが、必要なため呼び出す
+  //   Howler._autoResume();
+  // }
+  // Howler.mute(false);
 };
 
 /** オプション */

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -7,7 +7,7 @@ import { GameProps } from "../../game-props";
  * visibilityState = "hidden" の場合の処理
  */
 const onHidden = () => {
-  console.log("visibilityState = hidden"); // TODO: ログ出力を削除する
+  console.log("visibilityState = hidden", Howler.ctx); // TODO: ログ出力を削除する
   Howler.mute(true);
 };
 
@@ -15,23 +15,8 @@ const onHidden = () => {
  * visibilityState = "visible" の場合の処理
  */
 const onVisible = () => {
-  console.log("visibilityState = visible"); // TODO: ログ出力を削除する
+  console.log("visibilityState = visible", Howler.ctx); // TODO: ログ出力を削除する
   Howler.mute(false);
-  if (Howler.ctx && typeof Howler.ctx.resume === "function") {
-    Howler.ctx.resume().catch(() => {
-      // resume失敗時はユーザー操作で再試行
-      const tryResume = () => {
-        Howler.ctx.resume().then(() => {
-          // ここで再生中の音があれば再度play()を呼ぶ必要がある場合はここで呼ぶ
-        }).finally(() => {
-          document.body.removeEventListener("touchend", tryResume);
-          document.body.removeEventListener("mousedown", tryResume);
-        });
-      };
-      document.body.addEventListener("touchend", tryResume, { once: true });
-      document.body.addEventListener("mousedown", tryResume, { once: true });
-    });
-  }
 };
 
 /** オプション */

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -7,6 +7,7 @@ import { GameProps } from "../../game-props";
  * visibilityState = "hidden" の場合の処理
  */
 const onHidden = () => {
+  console.log("visibilityState = hidden"); // TODO: ログ出力を削除する
   Howler.mute(true);
 };
 
@@ -14,6 +15,7 @@ const onHidden = () => {
  * visibilityState = "visible" の場合の処理
  */
 const onVisible = () => {
+  console.log("visibilityState = visible"); // TODO: ログ出力を削除する
   Howler.mute(false);
   Howler.ctx.resume();
 };

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -8,7 +8,6 @@ import { GameProps } from "../../game-props";
  */
 const onHidden = () => {
   console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
-  Howler.autoUnlock = true;
   Howler.mute(true);
 };
 
@@ -17,6 +16,11 @@ const onHidden = () => {
  */
 const onVisible = () => {
   console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
+  // @ts-expect-error: _autoResumeの存在チェック
+  if (typeof Howler._autoResume === "function") {
+    // @ts-expect-error: _autoResumeはHowlerの内部メソッドだが、必要なため呼び出す
+    Howler._autoResume();
+  }
   Howler.mute(false);
 };
 

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -8,6 +8,7 @@ import { GameProps } from "../../game-props";
  */
 const onHidden = () => {
   console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
+  Howler.autoUnlock = true;
   Howler.mute(true);
 };
 

--- a/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
+++ b/src/js/game/game-procedure/on-game-action/on-visibility-change.ts
@@ -7,7 +7,6 @@ import { GameProps } from "../../game-props";
  * visibilityState = "hidden" の場合の処理
  */
 const onHidden = () => {
-  console.log("visibilityState = hidden", Howler); // TODO: ログ出力を削除する
   Howler.mute(true);
 };
 
@@ -34,7 +33,6 @@ const resumeHowlerAudioContextOnTouch = () => {
  * visibilityState = "visible" の場合の処理
  */
 const onVisible = () => {
-  console.log("visibilityState = visible", Howler); // TODO: ログ出力を削除する
   Howler.mute(false);
   document.addEventListener("touchstart", resumeHowlerAudioContextOnTouch, {
     once: true,


### PR DESCRIPTION
This pull request refactors the `onVisibilityChange` functionality in the `src/js/game/game-procedure/on-game-action/on-visibility-change.ts` file to improve audio handling when the game's visibility state changes. It introduces new helper functions for better modularity and adds logic to handle suspended WebAudioContext on touch devices.

### Refactoring and modularity:

* Introduced two helper functions, `onHidden` and `onVisible`, to encapsulate the logic for handling "hidden" and "visible" visibility states. This improves code readability and reusability. (`[[1]](diffhunk://#diff-dae547b014dce6dfe7bb5753673b013f7b0067a1e6fdb0d04bb170bc88ea22eeR6-R46)`, `[[2]](diffhunk://#diff-dae547b014dce6dfe7bb5753673b013f7b0067a1e6fdb0d04bb170bc88ea22eeL21-R66)`)

### Enhanced audio handling:

* Added a new function, `resumeHowlerAudioContextOnTouch`, to resume the `Howler` WebAudioContext when it is suspended. This is particularly necessary for touch devices like iPads and iPhones, where WebAudioContext may remain suspended after returning from the home screen. (`[src/js/game/game-procedure/on-game-action/on-visibility-change.tsR6-R46](diffhunk://#diff-dae547b014dce6dfe7bb5753673b013f7b0067a1e6fdb0d04bb170bc88ea22eeR6-R46)`)
* Updated the `onVisible` function to attach a `touchstart` event listener that triggers `resumeHowlerAudioContextOnTouch`. This ensures the WebAudioContext resumes only upon user interaction, adhering to browser requirements. (`[src/js/game/game-procedure/on-game-action/on-visibility-change.tsR6-R46](diffhunk://#diff-dae547b014dce6dfe7bb5753673b013f7b0067a1e6fdb0d04bb170bc88ea22eeR6-R46)`)