### PR TITLE
ポストバトルボタンのスタイルを調整した

### DIFF
--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -31,13 +31,12 @@
 }
 
 .post-battle__main-action::before {
-  content: "✨";
+  content: "🌟";
   margin-right: calc(var(--responsive-font-size) * 0.5);
 }
 
 .post-battle__main-action {
   border: 3px solid #00b0e6;
-  font-weight: bold;
   background-color: var(--button-background-color);
   box-shadow: var(--sub-button-box-shadow);
 }

--- a/src/css/post-battle.css
+++ b/src/css/post-battle.css
@@ -30,6 +30,11 @@
   box-shadow: var(--sub-button-box-shadow);
 }
 
+.post-battle__main-action::before {
+  content: "✨";
+  margin-right: calc(var(--responsive-font-size) * 0.5);
+}
+
 .post-battle__main-action {
   border: 3px solid #00b0e6;
   font-weight: bold;

--- a/src/js/game/post-battle-buttons.ts
+++ b/src/js/game/post-battle-buttons.ts
@@ -44,6 +44,11 @@ export const PostNetworkBattleButtons: PostBattleButtonConfig[] = [
 /** エピソード後（プレイヤーの勝利）のアクションボタン */
 export const PostEpisodeWinButtons: PostBattleButtonConfig[] = [
   {
+    style: "SubButton",
+    action: { type: "GotoEpisodeSelect" },
+    label: "エピソード選択へ",
+  },
+  {
     style: "MainButton",
     action: { type: "NextStage" },
     label: "次のエピソード",


### PR DESCRIPTION
This pull request introduces a new visual enhancement and an additional button option for post-battle actions. The most important changes include adding a decorative icon to the main action button and introducing a new "GotoEpisodeSelect" button for navigating to the episode selection screen.

### Visual Enhancements:
* [`src/css/post-battle.css`](diffhunk://#diff-ba4fb0e241254ac041d7594257de9aeb7d85ca96f39024e9570140b702e61203R33-L35): Added a star icon (`🌟`) to the `::before` pseudo-element of the `.post-battle__main-action` button for improved visual appeal.

### Functional Additions:
* [`src/js/game/post-battle-buttons.ts`](diffhunk://#diff-ab4b847361ea84de09820509509001dc997b231dba19fbfd59de3d8263d8593aR46-R50): Added a new "GotoEpisodeSelect" button configuration to the `PostEpisodeWinButtons` array, allowing users to navigate to the episode selection screen after winning an episode.