### PR TITLE
EP7を作り込んだ

### DIFF
--- a/src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts
@@ -11,8 +11,8 @@ import { scrollLeftMessages } from "../../scroll-messages";
 export async function playerLose(props: CustomBattleEventProps) {
   activeLeftMessageWindowWithFace(props, "Raito");
   await scrollLeftMessages(props, [
-    ["ライト", `「全国2位に${wbr}勝った`],
-    [`これで${wbr}名実ともに わいが${wbr}部長や」`],
+    ["ライト", `「これで${wbr}名実ともに わいが${wbr}部長や`],
+    [`これからは${wbr}ビシバシ${wbr}いかせて${wbr}もらうで」`],
   ]);
   props.view.dom.leftMessageWindow.darken();
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the dialogue in the `playerLose` function within `src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts`. The change updates the text displayed to reflect a new message when the player loses. 

The updated dialogue now includes a more detailed statement about future actions, replacing the previous message.