### PR TITLE
EP7作り込み + グランドーザアニメの調整

### DIFF
--- a/src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts
+++ b/src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts
@@ -12,7 +12,7 @@ export async function playerLose(props: CustomBattleEventProps) {
   activeLeftMessageWindowWithFace(props, "Raito");
   await scrollLeftMessages(props, [
     ["ライト", `「これで${wbr}名実ともに わいが${wbr}部長や`],
-    [`これからは${wbr}ビシバシ${wbr}いかせて${wbr}もらうで」`],
+    [`明日から${wbr}ビシバシ${wbr}いくから 覚悟せぇ」`],
   ]);
   props.view.dom.leftMessageWindow.darken();
 

--- a/src/js/game-object/armdozer/gran-dozer/animation/burst-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/burst-to-stand.ts
@@ -1,6 +1,9 @@
 import { delay } from "../../../../animation/delay";
 import { tween } from "../../../../animation/tween";
-import { ARMDOZER_SPRITE_ATTACKER_Z } from "../../../td-position";
+import {
+  ARMDOZER_SPRITE_ATTACKER_Z,
+  ARMDOZER_SPRITE_STANDARD_Z,
+} from "../../../td-position";
 import { GranDozerAnimationProps } from "./animation-props";
 
 /**
@@ -50,7 +53,13 @@ export function burstToStand(props: GranDozerAnimationProps) {
           .onStart(() => {
             model.animation.type = "STAND";
           })
-          .to({ animation: { frame: 0 } }, 0),
+          .to(
+            {
+              animation: { frame: 0 },
+              position: { z: ARMDOZER_SPRITE_STANDARD_Z },
+            },
+            0,
+          ),
       ),
     );
 }

--- a/src/js/game-object/armdozer/gran-dozer/meshes/create-animation-meshes.ts
+++ b/src/js/game-object/armdozer/gran-dozer/meshes/create-animation-meshes.ts
@@ -13,7 +13,7 @@ const MESH_HEIGHT = 920;
 
 /** オフセット座標 */
 const OFFSET = {
-  x: 90,
+  x: 100,
   y: 165,
 };
 

--- a/src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts
+++ b/src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts
@@ -10,7 +10,7 @@ import { GranDozerCutInView } from "./gran-dozer-cut-in-view";
 import { createMeshes } from "./meshes";
 
 /** ベースとなるpadding left */
-export const BASE_PADDING_LEFT = 150;
+export const BASE_PADDING_LEFT = 170;
 
 /** ベースとなるpadding top */
 export const BASE_PADDING_TOP = 135;


### PR DESCRIPTION
This pull request introduces several updates across different files to refine animations, adjust UI offsets, and improve dialogue text. The most notable changes involve modifying animation properties, updating sprite positions, and fine-tuning visual offsets for better alignment.

### Animation Updates:
* [`src/js/game-object/armdozer/gran-dozer/animation/burst-to-stand.ts`](diffhunk://#diff-ae04f805b4944f699cb80ef8c757d1aab0e591018c9bd1895bfd3bde097b6525L53-R62): Added `ARMDOZER_SPRITE_STANDARD_Z` to the sprite's `z` position during the transition from "BURST" to "STAND" animation. This ensures proper depth layering.
* [`src/js/game-object/armdozer/gran-dozer/animation/burst-to-stand.ts`](diffhunk://#diff-ae04f805b4944f699cb80ef8c757d1aab0e591018c9bd1895bfd3bde097b6525L3-R6): Imported `ARMDOZER_SPRITE_STANDARD_Z` to maintain consistency in animation depth definitions.

### UI Offset Adjustments:
* [`src/js/game-object/armdozer/gran-dozer/meshes/create-animation-meshes.ts`](diffhunk://#diff-dc6c32e3916814c740bd121650bacbbb14a966cf83b0baed8af51d25954895b3L16-R16): Adjusted the `OFFSET.x` value from `90` to `100` to refine the positioning of animation meshes.
* [`src/js/game-object/cut-in/gran-dozer/view/player-gran-dozer-cut-in-view.ts`](diffhunk://#diff-dfa53d68a29fb360ddca2ce7330976a3096fd7a43115be06cf7e134307d8b33cL13-R13): Increased `BASE_PADDING_LEFT` from `150` to `170` for better alignment of the cut-in view.

### Dialogue Refinement:
* [`src/js/custom-battle-events/survive-super-power-with-guard/stories/player-lose.ts`](diffhunk://#diff-82c27a8c1760709fcefe893da0073a9f73d862cfdfd792bf2c7e19b23362f8fdL15-R15): Updated dialogue text to improve clarity and flow, changing "これからはビシバシいかせてもらうで" to "明日からビシバシいくから 覚悟せぇ".