### PR TITLE
変更: DOMSceneBinderの型をDOMSceneBinderContainerに統一し、コードの一貫性を向上

### DIFF
--- a/src/js/dom-scenes/dom-scene-binder/dom-scene-binder-container.ts
+++ b/src/js/dom-scenes/dom-scene-binder/dom-scene-binder-container.ts
@@ -1,0 +1,7 @@
+import { DOMSceneBinder } from ".";
+
+/** DOMシーンバインダのコンテナ */
+export type DOMSceneBinderContainer = {
+  /** DOMシーンバインダ */
+  domSceneBinder: DOMSceneBinder;
+};

--- a/src/js/dom-scenes/dom-scene-binder/index.ts
+++ b/src/js/dom-scenes/dom-scene-binder/index.ts
@@ -51,3 +51,9 @@ export class DOMSceneBinder {
     return this.#props.scene !== null;
   }
 }
+
+/** DOMシーンバインダのコンテナ */
+export type DOMSceneBinderContainer = {
+  /** DOMシーンバインダ */
+  domSceneBinder: DOMSceneBinder;
+};

--- a/src/js/dom-scenes/dom-scene-binder/index.ts
+++ b/src/js/dom-scenes/dom-scene-binder/index.ts
@@ -51,9 +51,3 @@ export class DOMSceneBinder {
     return this.#props.scene !== null;
   }
 }
-
-/** DOMシーンバインダのコンテナ */
-export type DOMSceneBinderContainer = {
-  /** DOMシーンバインダ */
-  domSceneBinder: DOMSceneBinder;
-};

--- a/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
+++ b/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
@@ -4,7 +4,7 @@ import { createAbortError } from "../../../abort-controller/abort-error";
 import { AbortManagerContainer } from "../../../abort-controller/abort-manager-container";
 import { PostBattleFloater } from "../../../dom-floaters/post-battle";
 import { DOMScene } from "../../../dom-scenes/dom-scene";
-import { DOMSceneBinderContainer } from "../../../dom-scenes/dom-scene-binder";
+import { DOMSceneBinderContainer } from "../../../dom-scenes/dom-scene-binder/dom-scene-binder-container";
 import { TDSceneBinder } from "../../../td-scenes/td-scene-binder";
 
 /** シーン切り替えオプション */

--- a/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
+++ b/src/js/game/game-procedure/switch-scene/switch-dom-scene.ts
@@ -4,22 +4,21 @@ import { createAbortError } from "../../../abort-controller/abort-error";
 import { AbortManagerContainer } from "../../../abort-controller/abort-manager-container";
 import { PostBattleFloater } from "../../../dom-floaters/post-battle";
 import { DOMScene } from "../../../dom-scenes/dom-scene";
-import { DOMSceneBinder } from "../../../dom-scenes/dom-scene-binder";
+import { DOMSceneBinderContainer } from "../../../dom-scenes/dom-scene-binder";
 import { TDSceneBinder } from "../../../td-scenes/td-scene-binder";
 
 /** シーン切り替えオプション */
-type Options = Readonly<AbortManagerContainer> & {
-  /** DOMシーンバインダ */
-  readonly domSceneBinder: DOMSceneBinder;
-  /** 3Dシーンバインダ */
-  readonly tdSceneBinder: TDSceneBinder;
-  /** 切り替え先のDOMシーン */
-  readonly scene: DOMScene;
-  /** ポストバトルフローター */
-  readonly postBattle: PostBattleFloater;
-  /** バインドするシーンに関連するアンサブスクライバ */
-  readonly unsubscribers: Unsubscribable[];
-};
+type Options = Readonly<AbortManagerContainer> &
+  Readonly<DOMSceneBinderContainer> & {
+    /** 3Dシーンバインダ */
+    readonly tdSceneBinder: TDSceneBinder;
+    /** 切り替え先のDOMシーン */
+    readonly scene: DOMScene;
+    /** ポストバトルフローター */
+    readonly postBattle: PostBattleFloater;
+    /** バインドするシーンに関連するアンサブスクライバ */
+    readonly unsubscribers: Unsubscribable[];
+  };
 
 /**
  * DOMシーンに切り替える

--- a/src/js/game/game-props/index.ts
+++ b/src/js/game/game-props/index.ts
@@ -6,7 +6,7 @@ import { BGMManagerContainer } from "../../bgm/bgm-manager";
 import { CssHUDUIScale } from "../../css/hud-ui-scale";
 import { DOMDialogBinder } from "../../dom-dialogs/dom-dialog-binder";
 import { PostBattleFloater } from "../../dom-floaters/post-battle";
-import { DOMSceneBinder } from "../../dom-scenes/dom-scene-binder";
+import { DOMSceneBinderContainer } from "../../dom-scenes/dom-scene-binder";
 import { DOMFader } from "../../game-dom/dom-fader/dom-fader";
 import { GameLoopContainer } from "../../game-loop/game-loop-container";
 import { Renderer } from "../../render";
@@ -34,7 +34,8 @@ export interface GameProps
     SEPlayerContainer,
     GameActionManageContainer,
     Readonly<GameLoopContainer>,
-    Readonly<AbortManagerContainer> {
+    Readonly<AbortManagerContainer>,
+    Readonly<DOMSceneBinderContainer> {
   /** サービスワーカーを利用するか否か、trueで利用する */
   readonly isServiceWorkerUsed: boolean;
   /** APIサーバ系機能が利用可能か否か、trueで利用可能 */
@@ -87,8 +88,6 @@ export interface GameProps
   readonly fader: DOMFader;
   /** 強制割込シーン管理オブジェクト */
   readonly interruptScenes: InterruptScenes;
-  /** DOMシーンバインダー */
-  readonly domSceneBinder: DOMSceneBinder;
   /** DOMダイアログバインダー */
   readonly domDialogBinder: DOMDialogBinder;
   /** ポストバトルフローター */

--- a/src/js/game/game-props/index.ts
+++ b/src/js/game/game-props/index.ts
@@ -6,7 +6,7 @@ import { BGMManagerContainer } from "../../bgm/bgm-manager";
 import { CssHUDUIScale } from "../../css/hud-ui-scale";
 import { DOMDialogBinder } from "../../dom-dialogs/dom-dialog-binder";
 import { PostBattleFloater } from "../../dom-floaters/post-battle";
-import { DOMSceneBinderContainer } from "../../dom-scenes/dom-scene-binder";
+import { DOMSceneBinderContainer } from "../../dom-scenes/dom-scene-binder/dom-scene-binder-container";
 import { DOMFader } from "../../game-dom/dom-fader/dom-fader";
 import { GameLoopContainer } from "../../game-loop/game-loop-container";
 import { Renderer } from "../../render";


### PR DESCRIPTION
This pull request introduces a refactor to replace direct usage of the `DOMSceneBinder` type with a new container type, `DOMSceneBinderContainer`. This change improves type organization and consistency across the codebase by encapsulating the `DOMSceneBinder` within a container object.

### Refactor: Encapsulation of `DOMSceneBinder`

* **Added `DOMSceneBinderContainer` type**: Introduced a new type `DOMSceneBinderContainer` in `src/js/dom-scenes/dom-scene-binder/index.ts` to encapsulate the `DOMSceneBinder` object. This type provides a structured container for the DOM scene binder.

* **Updated `Options` type in `switch-dom-scene.ts`**: Replaced the direct use of `DOMSceneBinder` with `DOMSceneBinderContainer` in the `Options` type to ensure consistency and alignment with the new container structure.

* **Modified imports in `game-props/index.ts`**: Updated imports to use `DOMSceneBinderContainer` instead of `DOMSceneBinder`. This change reflects the adoption of the new container type across relevant modules.

* **Updated `GameProps` interface**: Replaced the `domSceneBinder` property with `Readonly<DOMSceneBinderContainer>` in the `GameProps` interface, ensuring the encapsulation of `DOMSceneBinder` in the container type.

* **Removed direct `domSceneBinder` property from `GameProps`**: Eliminated the standalone `domSceneBinder` property from the `GameProps` interface, as it is now encapsulated within the `DOMSceneBinderContainer`.