### PR TITLE
チュートリアル説明ダイアログのスタイルを調整

### DIFF
--- a/src/css/tutorial-description.css
+++ b/src/css/tutorial-description.css
@@ -49,7 +49,6 @@
 }
 
 .tutorial-description__description {
-  font-size: calc(var(--responsive-font-size) * 0.8);
   margin-bottom: calc(var(--responsive-font-size) * 2);
 }
 

--- a/src/css/tutorial-description.css
+++ b/src/css/tutorial-description.css
@@ -3,7 +3,6 @@
   .tutorial-description {
     --closer-width: 48px;
     --closer-height: 48px;
-    --dialog-padding: var(--responsive-font-size);
     --control-button-height: calc(var(--responsive-font-size) * 3);
 
     display: block;
@@ -28,6 +27,8 @@
 }
 
 .tutorial-description__dialog {
+  --dialog-padding: calc(var(--responsive-font-size) * 2);
+
   top: 50vh;
   top: 50dvh;
   left: 50vw;

--- a/src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs
@@ -6,7 +6,6 @@
     src="{{closerPath}}"
     data-id="closer"
   />
-  <div class="{{ROOT}}__title">チュートリアルをはじめますか？</div>
   <div class="{{ROOT}}__description">
     ストーリーモードの中からチュートリアル系ステージだけをプレイします。
   </div>


### PR DESCRIPTION
This pull request makes adjustments to the styling and structure of the tutorial description component. The most notable changes include updates to CSS variables for padding and font size, as well as the removal of a title element from the HTML structure.

### CSS Updates:

* [`src/css/tutorial-description.css`](diffhunk://#diff-906d1edc1d360fa1fb0ace037e08471c00843b3278045542e1c63fa8be03a9feL6): Removed the `--dialog-padding` variable from `.tutorial-description` and reintroduced it with a new value (`calc(var(--responsive-font-size) * 2)`) in `.tutorial-description__dialog`. This change standardizes padding across dialog elements. [[1]](diffhunk://#diff-906d1edc1d360fa1fb0ace037e08471c00843b3278045542e1c63fa8be03a9feL6) [[2]](diffhunk://#diff-906d1edc1d360fa1fb0ace037e08471c00843b3278045542e1c63fa8be03a9feR30-R31)
* [`src/css/tutorial-description.css`](diffhunk://#diff-906d1edc1d360fa1fb0ace037e08471c00843b3278045542e1c63fa8be03a9feL51): Removed the font size adjustment (`calc(var(--responsive-font-size) * 0.8)`) from `.tutorial-description__description`, simplifying the style definition.

### HTML Structure Changes:

* [`src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs`](diffhunk://#diff-3fb7a35a0b139befcf4011fa3dcda89c45ae630b1363b5f9e20c887989a2a3beL9): Removed the `<div>` element containing the title "チュートリアルをはじめますか？" from the tutorial description dialog, streamlining the content to focus on the description.