### PR TITLE
ライトニングドーザのルーチンを改良した

### DIFF
--- a/src/js/npc/very-hard-lightning-dozer.ts
+++ b/src/js/npc/very-hard-lightning-dozer.ts
@@ -28,6 +28,9 @@ const ZERO_BATTERY: Command = {
  */
 const getAttackRoutineConditions = (data: SimpleRoutineData) => ({
   pilot: data.commands.find((v) => v.type === "PILOT_SKILL_COMMAND"),
+  isBuffedPower: data.enemy.armdozer.effects.some(
+    (e) => e.type === "CorrectPower",
+  ),
   minimumBeatDownBattery: getMinimumBeatDownBattery(
     data.enemy,
     data.player,
@@ -45,12 +48,15 @@ const getAttackRoutineConditions = (data: SimpleRoutineData) => ({
  * 攻撃ルーチン
  */
 const attackRoutine: SimpleRoutine = (data) => {
-  const { pilot, minimumBeatDownBattery, minimumGuardBattery } =
+  const { pilot, isBuffedPower, minimumBeatDownBattery, minimumGuardBattery } =
     getAttackRoutineConditions(data);
   let selectedCommand: Command = ZERO_BATTERY;
 
   if (data.enemy.armdozer.battery === 5 && pilot) {
     selectedCommand = pilot;
+  } else if (data.enemy.armdozer.enableBurst && isBuffedPower) {
+    const battery = data.enemy.armdozer.battery;
+    selectedCommand = { type: "BATTERY_COMMAND", battery };
   } else if (minimumBeatDownBattery.isExist) {
     const battery = minimumBeatDownBattery.value;
     selectedCommand = { type: "BATTERY_COMMAND", battery };


### PR DESCRIPTION
This pull request updates the attack routine logic in the `src/js/npc/very-hard-lightning-dozer.ts` file to account for a new condition involving buffed power effects on the enemy's armdozer. The changes enhance the decision-making process for selecting commands during the attack routine.

### Updates to attack routine logic:

* [`src/js/npc/very-hard-lightning-dozer.ts`](diffhunk://#diff-38b3b9cf67e51e10fa241dc9cddb0c922c7b013de5251d24ff9400d1e8532495R31-R33): Added a new condition `isBuffedPower` that checks if the enemy's armdozer has a "CorrectPower" effect. This condition is now included in the `getAttackRoutineConditions` function.
* [`src/js/npc/very-hard-lightning-dozer.ts`](diffhunk://#diff-38b3b9cf67e51e10fa241dc9cddb0c922c7b013de5251d24ff9400d1e8532495L48-R59): Modified the `attackRoutine` logic to prioritize a `BATTERY_COMMAND` when the enemy's armdozer has `enableBurst` enabled and the `isBuffedPower` condition is true. This ensures a more strategic use of battery commands based on the enemy's status.