### PR TITLE
グランドーザを本番用リソースに移動させた

### DIFF
--- a/src/js/game/playable-amdozers.ts
+++ b/src/js/game/playable-amdozers.ts
@@ -9,13 +9,11 @@ export const PlayableArmdozers: ArmdozerId[] = [
   ArmdozerIds.NEO_LANDOZER,
   ArmdozerIds.LIGHTNING_DOZER,
   ArmdozerIds.GENESIS_BRAVER,
+  ArmdozerIds.GRAN_DOZER,
 ];
 
 /** 開発中も含めたプレイアブルアームドーザ */
-export const DevelopingPlayableArmdozers: ArmdozerId[] = [
-  ...PlayableArmdozers,
-  ArmdozerIds.GRAN_DOZER,
-];
+export const DevelopingPlayableArmdozers: ArmdozerId[] = [...PlayableArmdozers];
 
 /**
  * プレイアブルアームドーザを取得するヘルパー関数

--- a/src/js/game/story/episodes/index.ts
+++ b/src/js/game/story/episodes/index.ts
@@ -17,6 +17,7 @@ export const MainEpisodes: Episode[] = [
   pilotSkillTutorial01,
   pilotSkillTutorial02,
   confrontationTwoBraver,
+  surviveSuperPowerWithGuard,
 ];
 
 /** サイドエピソード */
@@ -28,6 +29,5 @@ export const Episodes: Episode[] = [...MainEpisodes, ...SideEpisodes];
 /** 開発中のエピソードをあつめたもの */
 export const EpisodesInDevelopment: Episode[] = [
   ...MainEpisodes,
-  surviveSuperPowerWithGuard,
   ...SideEpisodes,
 ];


### PR DESCRIPTION
This pull request updates the playable Armdozer lineup and episode lists to reflect the latest development status. The main changes include making `GRAN_DOZER` a standard playable Armdozer and updating the episode arrays so that `surviveSuperPowerWithGuard` is now part of the main episodes rather than being marked as in development.

Playable Armdozer updates:

* Added `GRAN_DOZER` to the `PlayableArmdozers` array, making it available for standard play.
* Updated `DevelopingPlayableArmdozers` to match `PlayableArmdozers`, removing `GRAN_DOZER` from the development-only list.

Episode list updates:

* Added `surviveSuperPowerWithGuard` to the `MainEpisodes` array, promoting it from development to a main episode.
* Removed `surviveSuperPowerWithGuard` from the `EpisodesInDevelopment` array, as it is now a main episode.