### PR TITLE
EP1のバッテリーセレクタ説明ウインドウのスタイルを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lint": "run-s lint:*",
     "lint-fix": "run-s lint-fix:*",
     "lint-fix:css": "stylelint --fix --max-warnings 0 \"src/**/*.css\"",
-    "lint-fix:hbs": "eslint --fix --max-warnings 0 -c eslint.hbs.config.js src/js",
+    "lint-fix:hbs": "eslint --fix --max-warnings 0 -c eslint.hbs.config.mjs src/js",
     "lint-fix:helper-ts": "eslint --fix --max-warnings 0 *.ts",
     "lint-fix:src": "eslint --fix --max-warnings 0 \"src/**/*.ts\" \"src/**/*.js\"",
     "lint-fix:storybook": "eslint --fix --max-warnings 0 stories",

--- a/src/css/message-window.css
+++ b/src/css/message-window.css
@@ -139,6 +139,7 @@
     width: var(--size);
     height: var(--size);
     margin: calc(var(--battle-window-font-size) * 0.2);
+    filter: brightness(0.95);
   }
 
   .message-window__attack-battery,
@@ -148,6 +149,7 @@
     width: var(--size);
     height: var(--size);
     margin: calc(var(--battle-window-font-size) * 0.2);
+    filter: brightness(0.95);
   }
 
   .message-window__highlight {

--- a/src/css/message-window.css
+++ b/src/css/message-window.css
@@ -13,6 +13,7 @@
     /** 本カスタムプロパティはJavaScriptから変更される */
     --brightness: brightness(1);
     --margin-x: max(3vw, var(--safe-area-left), var(--safe-area-right));
+    --window-width: calc(49vw - var(--margin-x));
     --window-height: calc(var(--battle-window-font-size) * 7);
     --shout-window-height: auto;
 
@@ -29,13 +30,13 @@
     border: var(--dialog-border);
     border-radius: var(--dialog-border-radius);
     padding: calc(var(--battle-window-font-size) * 1);
-    width: calc(49vw - var(--margin-x));
     filter: var(--brightness);
   }
 
   .message-window {
     left: 50vw;
     transform: translate(-50%, 0);
+    width: var(--window-width);
     min-height: var(--window-height);
   }
 
@@ -45,11 +46,13 @@
 
   .message-window--left {
     left: var(--margin-x);
+    width: var(--window-width);
     min-height: var(--window-height);
   }
 
   .message-window--right {
     right: var(--margin-x);
+    width: var(--window-width);
     min-height: var(--window-height);
   }
 
@@ -57,6 +60,7 @@
     --right-margin: max(10px, var(--safe-area-right));
 
     right: calc(var(--right-margin) + var(--hud-ui-scale) * 220px);
+    width: auto;
     min-height: var(--window-height);
   }
 
@@ -64,6 +68,7 @@
     --left-margin: max(10px, var(--safe-area-left));
 
     left: calc(var(--left-margin) + var(--hud-ui-scale) * 250px);
+    width: var(--window-width);
     min-height: var(--window-height);
   }
 
@@ -71,16 +76,19 @@
     --left-margin: max(10px, var(--safe-area-left));
 
     left: calc(var(--left-margin) + var(--hud-ui-scale) * 160px);
+    width: var(--window-width);
     min-height: var(--window-height);
   }
 
   .message-window--player-shout {
     right: var(--margin-x);
+    width: var(--window-width);
     height: var(--shout-window-height);
   }
 
   .message-window--enemy-shout {
     left: var(--margin-x);
+    width: var(--window-width);
     height: var(--shout-window-height);
   }
 

--- a/stories/message-window.stories.ts
+++ b/stories/message-window.stories.ts
@@ -298,7 +298,7 @@ export const messagesInInnerHTML = domStub((params) => {
 /** バッテリーシステムチュートリアルの攻撃バッテリーキャプション */
 export const attackBatteryCaption = domStub((params) => {
   const { resources } = params;
-  const dom = new MessageWindow(params);
+  const dom = new MessageWindow({ ...params, type: "NearBatterySelector" });
   dom.visible(true);
   dom.messagesInInnerHTML(attackBatteryCaptionInnerHtml(resources));
   return dom.getRootHTMLElement();


### PR DESCRIPTION
This pull request primarily refactors the CSS for message windows to improve maintainability and consistency, and makes a minor configuration update for linting. The most significant changes are the introduction of a reusable custom property for window width, the standardization of width assignments across message window variants, and a small adjustment to the linting configuration.

**CSS refactoring and consistency improvements:**

* Introduced a new custom property `--window-width` in `message-window.css` to centralize and reuse the calculation for window width.
* Updated all message window variants (such as `.message-window--left`, `.message-window--right`, `.message-window--near-burst-button`, etc.) to use the new `--window-width` property for their width, ensuring a consistent appearance and easier future maintenance. [[1]](diffhunk://#diff-a99266505be5ad9e1a9e441cc07a094a1b92404a32dbce29f2b0311606b942a2L32-R39) [[2]](diffhunk://#diff-a99266505be5ad9e1a9e441cc07a094a1b92404a32dbce29f2b0311606b942a2R49-R91)
* Applied a brightness filter to `.message-window__battery` and `.message-window__attack-battery` elements for improved visual clarity. [[1]](diffhunk://#diff-a99266505be5ad9e1a9e441cc07a094a1b92404a32dbce29f2b0311606b942a2R142) [[2]](diffhunk://#diff-a99266505be5ad9e1a9e441cc07a094a1b92404a32dbce29f2b0311606b942a2R152)

**Configuration and story updates:**

* Changed the ESLint configuration file for Handlebars linting from `eslint.hbs.config.js` to `eslint.hbs.config.mjs` in `package.json` to support ES module syntax.
* Updated the `attackBatteryCaption` story to explicitly set the message window type to `"NearBatterySelector"`, ensuring correct rendering in Storybook.