### PR TITLE
バースト、パイロットボタンの注釈ウインドウを修正

### DIFF
--- a/src/css/message-window.css
+++ b/src/css/message-window.css
@@ -73,6 +73,7 @@
     --left-margin: max(10px, var(--safe-area-left));
 
     left: calc(var(--left-margin) + var(--hud-ui-scale) * 250px);
+
     /**
      * バースト説明ウインドウは固定幅ではなく、
      * コンテンツに応じた最小幅で表示する方が見栄えが良い
@@ -85,7 +86,12 @@
     --left-margin: max(10px, var(--safe-area-left));
 
     left: calc(var(--left-margin) + var(--hud-ui-scale) * 160px);
-    width: var(--window-width);
+
+    /**
+     * パイロット説明ウインドウは固定幅ではなく、
+     * コンテンツに応じた最小幅で表示する方が見栄えが良い
+     */
+    width: auto;
     min-height: var(--window-height);
   }
 
@@ -106,7 +112,8 @@
     overflow: hidden;
   }
 
-  .message-window--near-burst-button .message-window__messages-wrapper {
+  .message-window--near-burst-button .message-window__messages-wrapper,
+  .message-window--near-pilot-button .message-window__messages-wrapper {
     display: flex;
     place-items: center;
   }

--- a/src/css/message-window.css
+++ b/src/css/message-window.css
@@ -73,7 +73,11 @@
     --left-margin: max(10px, var(--safe-area-left));
 
     left: calc(var(--left-margin) + var(--hud-ui-scale) * 250px);
-    width: var(--window-width);
+    /**
+     * バースト説明ウインドウは固定幅ではなく、
+     * コンテンツに応じた最小幅で表示する方が見栄えが良い
+     */
+    width: auto;
     min-height: var(--window-height);
   }
 
@@ -100,6 +104,11 @@
   .message-window__messages-wrapper {
     flex: 1 1;
     overflow: hidden;
+  }
+
+  .message-window--near-burst-button .message-window__messages-wrapper {
+    display: flex;
+    place-items: center;
   }
 
   .message-window__paragraph,

--- a/stories/message-window.stories.ts
+++ b/stories/message-window.stories.ts
@@ -317,7 +317,15 @@ export const defenseBatteryCaption = domStub((params) => {
 export const burstCaption = domStub((params) => {
   const dom = new MessageWindow({ ...params, type: "NearBurstButton" });
   dom.visible(true);
-  dom.messages(["バーストボタンを押そう"]);
+  dom.messages(['"バースト"ボタンを押そう']);
+  return dom.getRootHTMLElement();
+});
+
+/** パイロットボタン説明ウインドウ */
+export const pilotButtonCaption = domStub((params) => {
+  const dom = new MessageWindow({ ...params, type: "NearPilotButton" });
+  dom.visible(true);
+  dom.messages(['"パイロット"ボタンを押そう']);
   return dom.getRootHTMLElement();
 });
 

--- a/stories/message-window.stories.ts
+++ b/stories/message-window.stories.ts
@@ -313,6 +313,14 @@ export const defenseBatteryCaption = domStub((params) => {
   return dom.getRootHTMLElement();
 });
 
+/** バーストボタン説明ウインドウ */
+export const burstCaption = domStub((params) => {
+  const dom = new MessageWindow({ ...params, type: "NearBurstButton" });
+  dom.visible(true);
+  dom.messages(["バーストボタンを押そう"]);
+  return dom.getRootHTMLElement();
+});
+
 /** プレイヤー側の「よろしくお願いします」 */
 export const playerYorosikuOnegaishimasu = domStub((params) => {
   const dom = new MessageWindow({


### PR DESCRIPTION
This pull request updates the appearance and behavior of the burst and pilot explanation windows in the UI, making their widths responsive to content and improving their layout. It also adds new storybook examples for these windows.

**UI Improvements:**

* Changed `.message-window--near-burst-button` and `.message-window--near-pilot-button` in `message-window.css` to use `width: auto` instead of a fixed width, allowing the windows to size themselves based on content for better visual appearance.
* Updated the `.message-window__messages-wrapper` inside burst and pilot windows to use flex layout and center items, improving message alignment.

**Storybook Additions:**

* Added `burstCaption` and `pilotButtonCaption` exports to `message-window.stories.ts`, providing dedicated storybook examples for the burst and pilot explanation windows.