### PR TITLE
ステータスダイアログのバースト、パイロットスキル発動アイコンを修正

### DIFF
--- a/src/css/status.css
+++ b/src/css/status.css
@@ -140,7 +140,7 @@
   border-right: 1px dashed;
   margin-right: calc(var(--responsive-font-size) * 0.5);
   padding-right: calc(var(--responsive-font-size) * 0.5);
-  min-width: calc(var(--responsive-font-size) * 4);
+  width: calc(var(--responsive-font-size) * 4);
 }
 
 .status__burst-available-box,

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -59,7 +59,7 @@
   box-sizing: border-box;
   padding: max(var(--closer-height) / 2, var(--dialog-padding))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  width: min(
+  max-width: min(
     calc(
       100vw - var(--safe-area-right) - var(--safe-area-left) -
         var(--closer-width) * 0.5

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -144,7 +144,9 @@
 }
 
 .status__burst-available-box,
-.status__burst-disabled-box {
+.status__burst-disabled-box,
+.status__pilot-skill-available-box,
+.status__pilot-skill-disabled-box {
   --size: calc(var(--responsive-font-size) * 1.2);
 
   display: inline-block;
@@ -154,12 +156,14 @@
   border-radius: calc(var(--responsive-font-size) * 0.2);
 }
 
-.status__burst-available-box {
+.status__burst-available-box,
+.status__pilot-skill-available-box {
   background-color: #00ff7f;
   border: 1px solid #008042;
 }
 
-.status__burst-disabled-box {
+.status__burst-disabled-box,
+.status__pilot-skill-disabled-box {
   background-color: #696969;
   border: 1px solid #333333;
 }

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -156,10 +156,12 @@
 
 .status__burst-available-box {
   background-color: #00ff7f;
+  border: 1px solid #008042;
 }
 
 .status__burst-disabled-box {
   background-color: #696969;
+  border: 1px solid #333333;
 }
 
 /* ============================================================ 

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -59,12 +59,9 @@
   box-sizing: border-box;
   padding: max(var(--closer-height) / 2, var(--dialog-padding))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  max-width: min(
-    calc(
-      100vw - var(--safe-area-right) - var(--safe-area-left) -
-        var(--closer-width) * 0.5
-    ),
-    90vw
+  width: calc(
+    100vw - var(--safe-area-right) - var(--safe-area-left) -
+      var(--closer-width) - var(--responsive-font-size) * 2
   );
   display: grid;
   grid-template: "armdozer" "pilot" "effects";

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -143,8 +143,8 @@
   min-width: calc(var(--responsive-font-size) * 4);
 }
 
-.status__available-box,
-.status__disabled-box {
+.status__burst-available-box,
+.status__burst-disabled-box {
   --size: calc(var(--responsive-font-size) * 1.2);
 
   display: inline-block;
@@ -154,12 +154,12 @@
   border-radius: calc(var(--responsive-font-size) * 0.2);
 }
 
-.status__available-box {
+.status__burst-available-box {
   background-color: #00ff7f;
 }
 
-.status__disabled-box {
-  background-color: #ff7f7f;
+.status__burst-disabled-box {
+  background-color: #696969;
 }
 
 /* ============================================================ 

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -165,7 +165,7 @@
 .status__burst-disabled-box,
 .status__pilot-skill-disabled-box {
   background-color: #696969;
-  border: 1px solid #333333;
+  border: 1px solid #333;
 }
 
 /* ============================================================ 

--- a/src/js/dom-dialogs/status/dom/class-name.ts
+++ b/src/js/dom-dialogs/status/dom/class-name.ts
@@ -6,9 +6,3 @@ export const ARMDOZER_POWER_VALUE = `${ROOT}__armdozer-power-value`;
 
 /** アームドーザーパワーが強化されている場合の値のclass属性 */
 export const ARMDOZER_POWER_VALUE_BUFFED = `${ARMDOZER_POWER_VALUE}--buffed`;
-
-/** 発動可能ボックスのclass属性 */
-export const AVAILABLE_BOX = `${ROOT}__available-box`;
-
-/** 発動不可ボックスのclass属性 */
-export const DISABLED_BOX = `${ROOT}__disabled-box`;

--- a/src/js/dom-dialogs/status/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.hbs
@@ -101,10 +101,13 @@
         <div class="status__pilot-skill">
           <span class="status__pilot-skill-icon">
             <span class="status__pilot-skill-label">スキル</span>
-            <span class="{{pilotAvailableClassName}}"></span>
-            <span
-              class="status__available-caption"
-            >{{pilotAvailableCaption}}</span>
+            {{#if pilot.enableSkill}}
+              <span class="status__pilot-skill-available-box"></span>
+              <span class="status__pilot-skill-available-caption">発動可</span>
+            {{else}}
+              <span class="status__pilot-skill-disabled-box"></span>
+              <span class="status__pilot-skill-disabled-caption">発動済</span>
+            {{/if}}
           </span>
           <span class="status__pilot-skill-description">
             {{#if isPilotHidden}}

--- a/src/js/dom-dialogs/status/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.hbs
@@ -56,10 +56,13 @@
         <div class="status__burst">
           <span class="status__burst-icon">
             <span class="status__burst-label">バースト</span>
-            <span class="{{burstAvailableClassName}}"></span>
-            <span
-              class="status__available-caption"
-            >{{burstAvailableCaption}}</span>
+            {{#if armdozer.enableBurst}}
+              <span class="status__burst-available-box"></span>
+              <span class="status__burst-available-caption">発動可</span>
+            {{else}}
+              <span class="status__burst-disabled-box"></span>
+              <span class="status__burst-disabled-caption">発動済</span>
+            {{/if}}
           </span>
           <span class="status__burst-description">{{burstDescription}}</span>
         </div>

--- a/src/js/dom-dialogs/status/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.ts
@@ -10,16 +10,8 @@ import { PathIds } from "../../../resource/path/ids";
 import {
   ARMDOZER_POWER_VALUE,
   ARMDOZER_POWER_VALUE_BUFFED,
-  AVAILABLE_BOX,
-  DISABLED_BOX,
 } from "./class-name";
 import template from "./root-inner-html.hbs";
-
-/** 発動可能ラベル */
-const AVAILABLE = "発動可";
-
-/** 発動済ラベル */
-const DISABLED = "発動済";
 
 /** オプション */
 export type RootInnerHTMLOptions = ResourcesContainer & {
@@ -72,15 +64,6 @@ export function rootInnerHTML(options: RootInnerHTMLOptions): string {
   const batteryIconPath =
     resources.paths.find((p) => p.id === PathIds.BATTERY_ICON)?.path ?? "";
 
-  const burstAvailableClassName = armdozer.enableBurst
-    ? AVAILABLE_BOX
-    : DISABLED_BOX;
-  const burstAvailableCaption = armdozer.enableBurst ? AVAILABLE : DISABLED;
-  const pilotAvailableClassName = pilot.enableSkill
-    ? AVAILABLE_BOX
-    : DISABLED_BOX;
-  const pilotAvailableCaption = pilot.enableSkill ? AVAILABLE : DISABLED;
-
   return template({
     isEnemy,
     isPilotHidden,
@@ -97,10 +80,5 @@ export function rootInnerHTML(options: RootInnerHTMLOptions): string {
     armdozerIconPath,
     pilotIconPath,
     batteryIconPath,
-
-    burstAvailableClassName,
-    burstAvailableCaption,
-    pilotAvailableClassName,
-    pilotAvailableCaption,
   });
 }


### PR DESCRIPTION
This pull request refactors the way burst and pilot skill availability are displayed in the status dialog. Instead of using generic "available" and "disabled" box classes and captions, the code now uses more specific class names and handles the display logic directly in the template. This improves clarity and maintainability of both the CSS and the template logic.

**Refactor of burst and pilot skill availability display:**

* Replaced generic `.status__available-box` and `.status__disabled-box` with more specific classes: `.status__burst-available-box`, `.status__burst-disabled-box`, `.status__pilot-skill-available-box`, and `.status__pilot-skill-disabled-box` in both CSS and template. This includes new background and border styles for each state. [[1]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL143-R146) [[2]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL157-R165)
* Updated the Handlebars template (`root-inner-html.hbs`) to use conditional logic for displaying the appropriate availability box and caption for burst and pilot skill, removing the need for passing class names and captions from TypeScript. [[1]](diffhunk://#diff-421f95a9a04bf750fe857f54e186962fd3d56aa17dabf50d8c96118dcfa67e26L59-R65) [[2]](diffhunk://#diff-421f95a9a04bf750fe857f54e186962fd3d56aa17dabf50d8c96118dcfa67e26L101-R110)

**Code cleanup and simplification:**

* Removed unused constants and logic related to the previous "available" and "disabled" box class names and captions from `class-name.ts` and `root-inner-html.ts`. [[1]](diffhunk://#diff-52b819d17229230946f785585f87973d840c17c7bf4aa5895dbcfe9c244e8377L9-L14) [[2]](diffhunk://#diff-7c35dfdd257aa9d9c48fb575c4545540a7e1205192539c44f98d164b3368eedaL13-L23) [[3]](diffhunk://#diff-7c35dfdd257aa9d9c48fb575c4545540a7e1205192539c44f98d164b3368eedaL75-L83) [[4]](diffhunk://#diff-7c35dfdd257aa9d9c48fb575c4545540a7e1205192539c44f98d164b3368eedaL100-L104)

**CSS layout adjustment:**

* Adjusted the width calculation for the status dialog to improve responsiveness and layout.
* Changed the `.status__burst-icon` width from `min-width` to `width` for more consistent sizing.