### PR TITLE
ステータスダイアログの大きさ指定をdvw、dvhにした

### DIFF
--- a/src/css/status.css
+++ b/src/css/status.css
@@ -60,14 +60,14 @@
   padding: max(var(--closer-height) / 2, var(--dialog-padding))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   width: calc(
-    100vw -
+    100dvw -
       max(
         var(--safe-area-right) + var(--safe-area-left),
         var(--closer-width) + var(--responsive-font-size) * 2
       )
   );
   height: calc(
-    100vh -
+    100dvh -
       max(
         var(--safe-area-top) + var(--safe-area-bottom),
         var(--closer-height) + var(--responsive-font-size) * 2


### PR DESCRIPTION
This pull request makes a minor update to the `src/css/status.css` file, replacing the viewport units `vw` and `vh` with `dvw` and `dvh` for width and height calculations. This change ensures better compatibility with dynamic viewport sizing, especially on mobile devices.