### PR TITLE
ステータスダイアログのレイアウトを調整

### DIFF
--- a/src/css/status.css
+++ b/src/css/status.css
@@ -285,7 +285,7 @@
   grid-area: pilot-info;
   display: grid;
   grid-template:
-    "pilot-basic-status"
+    "pilot-name"
     "pilot-skill";
   gap: var(--grid-gap);
   background: rgb(23 23 23 / 60%);
@@ -295,11 +295,8 @@
   align-self: start;
 }
 
-.status__pilot-basic-status {
-  grid-area: pilot-basic-status;
-}
-
 .status__pilot-name {
+  grid-area: pilot-name;
   font-weight: bold;
 }
 

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -196,8 +196,9 @@
   grid-area: armdozer-info;
   display: grid;
   grid-template:
-    "armdozer-basic-status" auto
-    "burst" auto;
+    "armdozer-name"
+    "armdozer-basic-status"
+    "burst";
   gap: var(--grid-gap);
   background: rgb(23 23 23 / 60%);
   border-radius: calc(var(--responsive-font-size) * 0.5);
@@ -206,17 +207,17 @@
   align-items: start;
 }
 
+.status__armdozer-name {
+  grid-area: armdozer-name;
+  font-weight: bold;
+}
+
 .status__armdozer-basic-status {
   grid-area: armdozer-basic-status;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: var(--grid-gap);
-}
-
-.status__armdozer-name,
-.status__pilot-name {
-  font-weight: bold;
 }
 
 .status__armdozer-hp,
@@ -298,6 +299,10 @@
 
 .status__pilot-basic-status {
   grid-area: pilot-basic-status;
+}
+
+.status__pilot-name {
+  font-weight: bold;
 }
 
 .status__pilot-skill {

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -88,7 +88,7 @@
 .status__pilot-icon {
   display: grid;
   align-items: center;
-  width: calc(var(--responsive-font-size) * 4.5);
+  width: calc(var(--responsive-font-size) * 7);
   overflow: visible;
 
   /** 文字要素の下に表示されるようにz-indexを調整 */

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -205,6 +205,7 @@
   padding: calc(var(--responsive-font-size) * 0.2);
   box-sizing: border-box;
   align-items: start;
+  align-self: start;
 }
 
 .status__armdozer-name {

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -182,9 +182,7 @@
 .status__armdozer {
   grid-area: armdozer;
   display: grid;
-  grid-template:
-    "armdozer-icon armdozer-info"
-    "armdozer-icon armdozer-info" / auto 1fr;
+  grid-template: "armdozer-icon armdozer-info" / auto 1fr;
   gap: var(--grid-gap);
 }
 
@@ -266,9 +264,7 @@
 .status__pilot {
   grid-area: pilot;
   display: grid;
-  grid-template:
-    "pilot-icon pilot-info"
-    "pilot-icon pilot-info" / auto 1fr;
+  grid-template: "pilot-icon pilot-info" / auto 1fr;
   gap: var(--grid-gap);
 }
 
@@ -296,6 +292,7 @@
   border-radius: calc(var(--responsive-font-size) * 0.5);
   padding: calc(var(--responsive-font-size) * 0.2);
   box-sizing: border-box;
+  align-self: start;
 }
 
 .status__pilot-basic-status {

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -203,7 +203,7 @@
   padding: calc(var(--responsive-font-size) * 0.2);
   box-sizing: border-box;
   align-items: start;
-  align-self: start;
+  align-self: end;
 }
 
 .status__armdozer-name {
@@ -292,7 +292,7 @@
   border-radius: calc(var(--responsive-font-size) * 0.5);
   padding: calc(var(--responsive-font-size) * 0.2);
   box-sizing: border-box;
-  align-self: start;
+  align-self: end;
 }
 
 .status__pilot-name {

--- a/src/js/dom-dialogs/status/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.hbs
@@ -24,8 +24,8 @@
         {{/if}}
       </div>
       <div class="status__armdozer-info">
+        <div class="status__armdozer-name">{{armdozer.name}}</div>
         <div class="status__armdozer-basic-status">
-          <span class="status__armdozer-name">{{armdozer.name}}</span>
           <span class="status__armdozer-hp">
             <span class="status__armdozer-hp-label">HP</span>
             <span class="status__armdozer-hp-value">

--- a/src/js/dom-dialogs/status/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.hbs
@@ -89,15 +89,13 @@
         {{/if}}
       </div>
       <div class="status__pilot-info">
-        <div class="status__pilot-basic-status">
-          <span class="status__pilot-name">
-            {{#if isPilotHidden}}
-              ???
-            {{else}}
-              {{pilot.name}}
-            {{/if}}
-          </span>
-        </div>
+        <span class="status__pilot-name">
+          {{#if isPilotHidden}}
+            ???
+          {{else}}
+            {{pilot.name}}
+          {{/if}}
+        </span>
         <div class="status__pilot-skill">
           <span class="status__pilot-skill-icon">
             <span class="status__pilot-skill-label">スキル</span>


### PR DESCRIPTION
This pull request updates the layout and styling of the status display for both Armdozer and Pilot sections, improving their structure, alignment, and visual hierarchy. The main changes involve restructuring the grid layouts, separating name display elements for better styling, and adjusting icon sizes for improved appearance.

**Layout and Structure Improvements:**

* Refactored the grid layouts for `.status__armdozer` and `.status__pilot` to use a single-row template, simplifying the structure and making it more maintainable. [[1]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL185-R185) [[2]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL267-R267)
* Updated the `.status__armdozer-info` and `.status__pilot-info` grid templates to introduce dedicated areas for names, and ensured proper alignment with `align-self: end`. [[1]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL199-R211) [[2]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL290-R300)

**Visual Hierarchy and Styling:**

* Moved the Armdozer and Pilot name elements out of the "basic status" sections into their own containers, and applied bold styling specifically to these name elements for clearer emphasis. [[1]](diffhunk://#diff-421f95a9a04bf750fe857f54e186962fd3d56aa17dabf50d8c96118dcfa67e26R27-L28) [[2]](diffhunk://#diff-421f95a9a04bf750fe857f54e186962fd3d56aa17dabf50d8c96118dcfa67e26L92-L100) [[3]](diffhunk://#diff-cc1292f733abca3f0e95bb50248573171ac5a2889b5adbded770d0369541bb5fL217-L221)
* Increased the size of the `.status__pilot-icon` for better visibility.

These changes collectively enhance the clarity and visual organization of the status display, making important information like names and icons more prominent and easier to read.