### PR TITLE
アウトラインテクスチャ生成処理を別関数として切り出した

### DIFF
--- a/src/js/game-object/armdozer/mesh/create-outline-mesh.ts
+++ b/src/js/game-object/armdozer/mesh/create-outline-mesh.ts
@@ -1,47 +1,14 @@
 import * as THREE from "three";
 
-import { toSilhouette } from "../../../canvas/to-silhouette";
 import { HorizontalAnimationMesh } from "../../../mesh/horizontal-animation";
 import { ResourcesContainer } from "../../../resource";
 import { findTextureOrThrow } from "../../../resource/find-texture-or-throw";
 import { TextureId } from "../../../resource/texture/resource";
-import { CanvasDisposeTexture } from "../../../texture/canvas-dispose-texture";
+import {
+  createOutlineSilhouetteTexture,
+  OutlineColor,
+} from "../../../texture/create-outline-silhouette-texture";
 import { ArmdozerAnimation } from "./armdozer-animation";
-
-/** アウトラインカラー */
-type OutlineColor = {
-  /** アウトライン Red */
-  r: number;
-  /** アウトライン Green */
-  g: number;
-  /** アウトライン Blue */
-  b: number;
-};
-
-/** createOutlineSilhouetteTexture オプション */
-type CreateOutlineSilhouetteTextureOptions = {
-  /** 加工前のテクスチャ */
-  texture: THREE.Texture;
-  /** アウトラインカラー */
-  color: OutlineColor;
-};
-
-/**
- * アウトライン用にシルエット化したテクスチャを生成する
- * @param options オプション
- * @returns シルエット化したテクスチャ
- */
-function createOutlineSilhouetteTexture(
-  options: CreateOutlineSilhouetteTextureOptions,
-): THREE.Texture {
-  const { texture, color } = options;
-  const canvas = toSilhouette({
-    ...color,
-    image: texture.image,
-    scale: 0.5,
-  });
-  return new CanvasDisposeTexture(canvas);
-}
 
 /** createOutlineMesh オプション */
 type CreateOutlineMeshOptions = ResourcesContainer & {

--- a/src/js/texture/create-outline-silhouette-texture.ts
+++ b/src/js/texture/create-outline-silhouette-texture.ts
@@ -1,0 +1,39 @@
+import * as THREE from "three";
+
+import { toSilhouette } from "../canvas/to-silhouette";
+import { CanvasDisposeTexture } from "./canvas-dispose-texture";
+
+/** アウトラインカラー */
+export type OutlineColor = {
+  /** アウトライン Red */
+  r: number;
+  /** アウトライン Green */
+  g: number;
+  /** アウトライン Blue */
+  b: number;
+};
+
+/** createOutlineSilhouetteTexture オプション */
+type CreateOutlineSilhouetteTextureOptions = {
+  /** 加工前のテクスチャ */
+  texture: THREE.Texture;
+  /** アウトラインカラー */
+  color: OutlineColor;
+};
+
+/**
+ * アウトライン用にシルエット化したテクスチャを生成する
+ * @param options オプション
+ * @returns シルエット化したテクスチャ
+ */
+export function createOutlineSilhouetteTexture(
+  options: CreateOutlineSilhouetteTextureOptions,
+): THREE.Texture {
+  const { texture, color } = options;
+  const canvas = toSilhouette({
+    ...color,
+    image: texture.image,
+    scale: 0.5,
+  });
+  return new CanvasDisposeTexture(canvas);
+}


### PR DESCRIPTION
This pull request refactors the outline mesh creation logic by moving the outline silhouette texture generation code and its related types from `armdozer/mesh/create-outline-mesh.ts` to a new dedicated module, `texture/create-outline-silhouette-texture.ts`. This improves code organization and modularity, making the outline texture creation reusable and easier to maintain.

**Code organization and modularization:**

* Moved the `OutlineColor` type, `createOutlineSilhouetteTexture` function, and related types from `src/js/game-object/armdozer/mesh/create-outline-mesh.ts` to the new file `src/js/texture/create-outline-silhouette-texture.ts`. [[1]](diffhunk://#diff-cba6b557b5e1d98f5f0428715601c0fad77270d9cfc68e987b74f4f7c928e79cL3-L45) [[2]](diffhunk://#diff-780a1e57e03c5607e5f6f978b1d6a66192278f6c2e9cce1c828682f754cf1d8dR1-R39)
* Updated imports in `create-outline-mesh.ts` to reference the new module for outline texture creation.

**Functionality preservation:**

* The logic for generating silhouette textures with outlines remains unchanged, ensuring no functional regressions.