### PR TITLE
バッテリーセレクタのアイコンを修正した

### DIFF
--- a/src/js/game-object/battery-selector/view/battery-selector-icon/genesis-braver-attack-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/genesis-braver-attack-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 570;
+const MESH_SIZE = 540;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 60;
@@ -62,6 +62,6 @@ export const genesisBraverAttackIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value);
     },
-    position: { x: 40, y: 100 },
+    position: { x: 40, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/genesis-braver-defense-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/genesis-braver-defense-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 600;
+const MESH_SIZE = 540;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 50;
@@ -62,6 +62,6 @@ export const genesisBraverDefenseIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value * 0.8);
     },
-    position: { x: -10, y: 100 },
+    position: { x: -10, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/gran-dozer-attack-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/gran-dozer-attack-icon.ts
@@ -8,10 +8,10 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 630;
+const MESH_SIZE = 540;
 
 /** アウトラインメッシュのサイズ */
-const OUTLINE_SIZE = MESH_SIZE + 60;
+const OUTLINE_SIZE = MESH_SIZE + 50;
 
 /**
  * グランドーザ攻撃アイコンを生成する
@@ -62,6 +62,6 @@ export const granDozerAttackIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value);
     },
-    position: { x: 20, y: 80 },
+    position: { x: 20, y: 60 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/gran-dozer-defense-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/gran-dozer-defense-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 660;
+const MESH_SIZE = 540;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 50;
@@ -62,6 +62,6 @@ export const granDozerDefenseIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value * 0.8);
     },
-    position: { x: -10, y: 80 },
+    position: { x: -10, y: 60 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/lightning-dozer-attack-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/lightning-dozer-attack-icon.ts
@@ -8,10 +8,10 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 550;
+const MESH_SIZE = 500;
 
 /** アウトラインメッシュのサイズ */
-const OUTLINE_SIZE = MESH_SIZE + 50;
+const OUTLINE_SIZE = MESH_SIZE + 35;
 
 /**
  * ライトニングドーザ攻撃アイコンを生成する
@@ -62,6 +62,6 @@ export const lightningDozerAttackIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value);
     },
-    position: { x: 10, y: 95 },
+    position: { x: 10, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/lightning-dozer-defense-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/lightning-dozer-defense-icon.ts
@@ -8,10 +8,10 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 600;
+const MESH_SIZE = 500;
 
 /** アウトラインメッシュのサイズ */
-const OUTLINE_SIZE = MESH_SIZE + 50;
+const OUTLINE_SIZE = MESH_SIZE + 35;
 
 /**
  * ライトニングドーザ防御アイコンを生成する
@@ -62,6 +62,6 @@ export const lightningDozerDefenseIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value * 0.8);
     },
-    position: { x: 20, y: 100 },
+    position: { x: 20, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/neo-landozer-attack-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/neo-landozer-attack-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 550;
+const MESH_SIZE = 500;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 50;
@@ -62,6 +62,6 @@ export const neoLandozerAttackIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value);
     },
-    position: { x: 40, y: 110 },
+    position: { x: 40, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/neo-landozer-defense-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/neo-landozer-defense-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 580;
+const MESH_SIZE = 500;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 50;
@@ -62,6 +62,6 @@ export const neoLandozerDefenseIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value * 0.8);
     },
-    position: { x: 0, y: 100 },
+    position: { x: 0, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/wing-dozer-attack-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/wing-dozer-attack-icon.ts
@@ -8,7 +8,7 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 510;
+const MESH_SIZE = 470;
 
 /** アウトラインメッシュのサイズ */
 const OUTLINE_SIZE = MESH_SIZE + 35;
@@ -62,6 +62,6 @@ export const wingDozerAttackIcon = (
       mesh.opacity(value);
       outlineMesh.opacity(value);
     },
-    position: { x: 65, y: 95 },
+    position: { x: 65, y: 90 },
   };
 };

--- a/src/js/game-object/battery-selector/view/battery-selector-icon/wing-dozer-defense-icon.ts
+++ b/src/js/game-object/battery-selector/view/battery-selector-icon/wing-dozer-defense-icon.ts
@@ -8,10 +8,10 @@ import { createOutlineSilhouetteTexture } from "../../../../texture/create-outli
 import { BatterySelectorIcon } from "./battery-selector-icon";
 
 /** メッシュのサイズ */
-const MESH_SIZE = 540;
+const MESH_SIZE = 500;
 
 /** アウトラインメッシュのサイズ */
-const OUTLINE_SIZE = MESH_SIZE + 50;
+const OUTLINE_SIZE = MESH_SIZE + 35;
 
 /**
  * ウィングドーザ防御アイコンを生成する


### PR DESCRIPTION
This pull request standardizes the sizing and positioning of battery selector icons for various game objects. The main focus is on making mesh and outline sizes consistent across attack and defense icons, and adjusting their positions for better alignment.

**Icon sizing standardization:**

* Reduced `MESH_SIZE` for all icons to either 540, 500, or 470, depending on the icon, ensuring consistency in appearance. [[1]](diffhunk://#diff-9a6a2c289726dc2ae0b7d9bb529a35d192b7de3bf0f1fd03960cc693b89abc57L11-R11) [[2]](diffhunk://#diff-46c6ce618db5f46a12d883303f6b3309a792c31ee5d1ce0e6c6b2c50d154d19cL11-R11) [[3]](diffhunk://#diff-fe51060d5e6cd20831d479f4bacde8dfc5a7b0da79a91e439aa8fcebd9e7b209L11-R14) [[4]](diffhunk://#diff-94de7c4870c65f2395119405407dbab78c91a7f92b6efa31fce660d44ede41e7L11-R11) [[5]](diffhunk://#diff-b318501f41665ba3f7675c38438dd5dbf16062715d325813d687735cc5945693L11-R14) [[6]](diffhunk://#diff-3bbfd677f348e40c8af573d9a634c0f821de9f4f43d09fe7a4d8de03993ec8faL11-R14) [[7]](diffhunk://#diff-ae2e3ff2672bda4fd2d841e020259c7311eb07fc6a7555a79d680956d1162cc1L11-R11) [[8]](diffhunk://#diff-78d6b8a8513e3746cfe26cddc62f5b44d0f79bea4e0ca2c59d58748f0ddf9779L11-R11) [[9]](diffhunk://#diff-43ce50fc7d722fe118b17ea3067ccb78b149be6bc2663b68c177dc5ede6ba9aeL11-R11) [[10]](diffhunk://#diff-d598a2d45761b1988af08724e99e63e941cb1636bac92aa1ff8e0e24c5056824L11-R14)
* Adjusted `OUTLINE_SIZE` values to maintain proportional outlines relative to the new mesh sizes. [[1]](diffhunk://#diff-fe51060d5e6cd20831d479f4bacde8dfc5a7b0da79a91e439aa8fcebd9e7b209L11-R14) [[2]](diffhunk://#diff-b318501f41665ba3f7675c38438dd5dbf16062715d325813d687735cc5945693L11-R14) [[3]](diffhunk://#diff-3bbfd677f348e40c8af573d9a634c0f821de9f4f43d09fe7a4d8de03993ec8faL11-R14) [[4]](diffhunk://#diff-d598a2d45761b1988af08724e99e63e941cb1636bac92aa1ff8e0e24c5056824L11-R14)

**Icon position alignment:**

* Updated the `position` property for all icons, generally lowering the `y` value to improve vertical alignment and visual consistency. [[1]](diffhunk://#diff-9a6a2c289726dc2ae0b7d9bb529a35d192b7de3bf0f1fd03960cc693b89abc57L65-R65) [[2]](diffhunk://#diff-46c6ce618db5f46a12d883303f6b3309a792c31ee5d1ce0e6c6b2c50d154d19cL65-R65) [[3]](diffhunk://#diff-fe51060d5e6cd20831d479f4bacde8dfc5a7b0da79a91e439aa8fcebd9e7b209L65-R65) [[4]](diffhunk://#diff-94de7c4870c65f2395119405407dbab78c91a7f92b6efa31fce660d44ede41e7L65-R65) [[5]](diffhunk://#diff-b318501f41665ba3f7675c38438dd5dbf16062715d325813d687735cc5945693L65-R65) [[6]](diffhunk://#diff-3bbfd677f348e40c8af573d9a634c0f821de9f4f43d09fe7a4d8de03993ec8faL65-R65) [[7]](diffhunk://#diff-ae2e3ff2672bda4fd2d841e020259c7311eb07fc6a7555a79d680956d1162cc1L65-R65) [[8]](diffhunk://#diff-78d6b8a8513e3746cfe26cddc62f5b44d0f79bea4e0ca2c59d58748f0ddf9779L65-R65) [[9]](diffhunk://#diff-43ce50fc7d722fe118b17ea3067ccb78b149be6bc2663b68c177dc5ede6ba9aeL65-R65)

These changes collectively make the battery selector icons more visually uniform and better aligned within the UI.