### PR TITLE
EP6.2のセリフを修正

### DIFF
--- a/src/js/custom-battle-events/prince-of-fallen-sun/stories/introduction.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/stories/introduction.ts
@@ -58,7 +58,9 @@ export async function introduction(props: CustomBattleEventProps) {
   activeRightMessageWindowWithFace(props, "Raito");
   await scrollRightMessages(props, [
     ["ライト", `「ダメや！！`],
-    [`試合前に${wbr}手の内を${wbr}明かすなんて${wbr}自殺行為や」`],
+    [
+      `公式戦の${wbr}前に 対Gブレイバーの${wbr}秘策を${wbr}明かす${wbr}つもりか」`,
+    ],
   ]);
   props.view.dom.rightMessageWindow.darken();
 

--- a/src/js/custom-battle-events/prince-of-fallen-sun/stories/san-of-noble.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/stories/san-of-noble.ts
@@ -29,7 +29,7 @@ export async function sunOfNoble(props: CustomBattleEventProps) {
   await scrollRightMessages(props, [
     ["ユウヤ", `「感激だな`],
     [
-      `まさか${wbr}巨大ロボの${wbr}創業家の${wbr}人間と${wbr}手合わせ${wbr}できる${wbr}とはな」`,
+      `まさか${wbr}巨大ロボの${wbr}創業家と${wbr}手合わせ${wbr}できる${wbr}とはな」`,
     ],
   ]);
   props.view.dom.rightMessageWindow.darken();

--- a/src/js/custom-battle-events/prince-of-fallen-sun/stories/yuuya-victory.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/stories/yuuya-victory.ts
@@ -26,7 +26,7 @@ export async function yuuyaVictory(props: CustomBattleEventProps) {
       `特に${wbr}攻撃${wbr}・耐久性能は${wbr}Gブレイバーより${wbr}上で 目を${wbr}見張る${wbr}ものが${wbr}ある`,
     ],
     [`だが ロボの${wbr}性能だけで${wbr}試合は${wbr}決まらない`],
-    [`一番大事なのは パイロット同士の${wbr}読み合い${wbr}なんだぜ」`],
+    [`一番大事なのは パイロット同士の${wbr}読み合いだ」`],
   ]);
 
   invisibleAllMessageWindows(props);


### PR DESCRIPTION
This pull request updates dialogue text in several story event scripts to improve clarity and accuracy. The changes focus on refining character lines and correcting phrasing in the `prince-of-fallen-sun` storyline.

Dialogue improvements:

* In `introduction.ts`, Raito's line about revealing strategies before an official match is clarified to specifically mention a secret tactic against G-Braver.
* In `san-of-noble.ts`, Yuya's line is simplified by removing the reference to "創業家の人間" (member of the founding family) and instead referencing just the founding family.
* In `yuuya-victory.ts`, Yuya's line about the importance of reading the opponent is corrected for natural phrasing, removing a redundant phrase.