### PR TITLE
戦闘終了BGMの再生タイミングを調整

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
@@ -26,7 +26,7 @@ export function down(param: GenesisBraverBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.spToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { GenesisBraverBattle } from "./genesis-braver-battle";
@@ -25,7 +25,9 @@ export function down(param: GenesisBraverBattle<DownResult>): Animate {
     .chain(param.attackerSprite.straightPunch())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.spToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator
           .slideIn()

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
@@ -26,7 +26,7 @@ export function down(param: GranDozerBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.tackleToStand())

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { GranDozerBattle } from "./gran-dozer-battle";
@@ -25,7 +25,9 @@ export function down(param: GranDozerBattle<DownResult>): Animate {
     .chain(param.attackerSprite.tackle())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.tackleToStand())
           .chain(delay(500)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { LightningDozerBattle } from "./lightning-dozer-battle";
@@ -25,7 +25,9 @@ export function down(param: LightningDozerBattle<DownResult>): Animate {
     .chain(param.attackerSprite.armHammer())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator
           .slideIn()

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
@@ -26,7 +26,7 @@ export function down(param: LightningDozerBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { NeoLandozerBattle } from "./neo-landozer-battle";
@@ -25,7 +25,9 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
     .chain(param.attackerSprite.armHammer())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator
           .slideIn()

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -26,7 +26,7 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         param.attackerHUD.resultIndicator

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -26,7 +26,7 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.punchToStand())

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { ShinBraverBattle } from "./shin-braver-battle";
@@ -25,7 +25,9 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
     .chain(param.attackerSprite.straightPunch())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.punchToStand())
           .chain(delay(500)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
@@ -4,7 +4,7 @@ import { all } from "../../../../../../../animation/all";
 import { Animate } from "../../../../../../../animation/animate";
 import { delay } from "../../../../../../../animation/delay";
 import { onStart } from "../../../../../../../animation/on-start";
-import { play } from "../../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../../bgm/bgm-operators";
 import { toInitial } from "../../../../td-camera";
 import { focusToAttacker } from "./focus-to-attacker";
 import { WingDozerBattle } from "./wing-dozer-battle";
@@ -25,7 +25,9 @@ export function down(param: WingDozerBattle<DownResult>): Animate {
     .chain(param.attackerSprite.upper())
     .chain(
       all(
-        delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+        onStart(() => param.bgm.do(stop))
+          .chain(delay(200))
+          .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.upperToStand())
           .chain(delay(500)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
@@ -26,7 +26,7 @@ export function down(param: WingDozerBattle<DownResult>): Animate {
     .chain(
       all(
         onStart(() => param.bgm.do(stop))
-          .chain(delay(200))
+          .chain(delay(100))
           .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
         delay(1500)
           .chain(param.attackerSprite.upperToStand())

--- a/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
@@ -2,7 +2,7 @@ import { all } from "../../../../../../animation/all";
 import { Animate } from "../../../../../../animation/animate";
 import { delay } from "../../../../../../animation/delay";
 import { onStart } from "../../../../../../animation/on-start";
-import { play } from "../../../../../../bgm/bgm-operators";
+import { play, stop } from "../../../../../../bgm/bgm-operators";
 import { ReflectAnimationParam } from "../animation-param";
 
 /**
@@ -12,7 +12,9 @@ import { ReflectAnimationParam } from "../animation-param";
  */
 export const deathLightning = (param: ReflectAnimationParam): Animate =>
   all(
-    delay(300).chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
+    onStart(() => param.bgm.do(stop))
+      .chain(delay(200))
+      .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
     param.reflecting.hud.resultIndicator
       .slideIn()
       .chain(delay(700))

--- a/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
@@ -13,7 +13,7 @@ import { ReflectAnimationParam } from "../animation-param";
 export const deathLightning = (param: ReflectAnimationParam): Animate =>
   all(
     onStart(() => param.bgm.do(stop))
-      .chain(delay(200))
+      .chain(delay(100))
       .chain(onStart(() => param.bgm.do(play(param.battleEndBGM)))),
     param.reflecting.hud.resultIndicator
       .slideIn()


### PR DESCRIPTION
This pull request updates the battle animation sequences for several attack and reflect scenarios to ensure that the background music (BGM) is properly stopped before playing the battle end BGM. Previously, the new BGM was played after a delay, but the old BGM could still be running. Now, the code explicitly stops the current BGM, waits briefly, and then plays the battle end BGM for a smoother audio transition.

**Battle Animation BGM Handling Improvements:**

* Added `stop` from `bgm-operators` and updated the animation sequence in the following attack down animation files to stop the current BGM, delay, and then play the battle end BGM:  
  * `genesis-braver/down.ts` [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L7-R7) [[2]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L28-R30)
  * `gran-dozer/down.ts` [[1]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L7-R7) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L28-R30)
  * `lightning-dozer/down.ts` [[1]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L7-R7) [[2]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L28-R30)
  * `neo-landozer/down.ts` [[1]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L7-R7) [[2]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L28-R30)
  * `shin-braver/down.ts` [[1]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L7-R7) [[2]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L28-R30)
  * `wing-dozer/down.ts` [[1]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL7-R7) [[2]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL28-R30)

* Applied the same BGM stop-then-play logic to the reflect animation for death lightning in `death-lightning.ts` [[1]](diffhunk://#diff-a4d09f34ebbc75fa731d9b82830f398cd182edf2c9b640d5e7b90d729aeb9942L5-R5) [[2]](diffhunk://#diff-a4d09f34ebbc75fa731d9b82830f398cd182edf2c9b640d5e7b90d729aeb9942L15-R17)